### PR TITLE
Fix README image paths for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Fix relative image paths in README for PyPI
+        run: |
+          sed -i 's|src="docs/|src="https://raw.githubusercontent.com/hendrickmelo/versionable/main/docs/|g' README.md
+          sed -i 's|(docs/|(https://raw.githubusercontent.com/hendrickmelo/versionable/main/docs/|g' README.md
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/pixi.lock
+++ b/pixi.lock
@@ -5068,8 +5068,8 @@ packages:
   timestamp: 1767320173250
 - pypi: ./
   name: versionable
-  version: 0.0.1.dev1
-  sha256: 9a3925ecf84bcc9314646e9da08fbb03284cdf5b5cca745e356affccba5591d1
+  version: 0.0.1.dev2
+  sha256: 80cebdfa0a3ca33222cfdfb42288d4a6c2f2cf4712fa4b77e0480bce24f585ff
   requires_dist:
   - toml>=0.10
   - pyyaml>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "versionable"
-version = "0.0.1.dev1"
+version = "0.0.1.dev2"
 description = "Versioned persistence for Python dataclasses with hash validation, declarative migrations, and pluggable backends"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Description:** Rewrite relative docs/ image paths to absolute raw GitHub URLs in the publish workflow so images render on PyPI.

**Changes:**

- Add sed step in publish workflow to rewrite image paths before building
- Bump version to 0.0.1.dev2