### PR TITLE
Skip dev version bump for pre-release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 
   bump-dev-version:
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && !github.event.release.prerelease
     needs: publish
     runs-on: ubuntu-latest
     permissions:

--- a/pixi.lock
+++ b/pixi.lock
@@ -5068,8 +5068,8 @@ packages:
   timestamp: 1767320173250
 - pypi: ./
   name: versionable
-  version: 0.0.1.dev2
-  sha256: 80cebdfa0a3ca33222cfdfb42288d4a6c2f2cf4712fa4b77e0480bce24f585ff
+  version: 0.0.1.dev3
+  sha256: e1f6cb654c706ec15177450869e750c9c4150257bcb00dd5439366c183747b4a
   requires_dist:
   - toml>=0.10
   - pyyaml>=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "versionable"
-version = "0.0.1.dev2"
+version = "0.0.1.dev3"
 description = "Versioned persistence for Python dataclasses with hash validation, declarative migrations, and pluggable backends"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Description:** Pre-release tags (rc, alpha, beta) should not trigger the post-release version bump.

**Changes:**

- Add `!github.event.release.prerelease` condition to bump-dev-version job
- Bump version to 0.0.1.dev3