### PR TITLE
Native HDF5 storage — no JSON anywhere in .h5 files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -161,7 +161,7 @@ Initialize logger: `logger = logging.getLogger(__name__)`
 - **`_backend.py`** — Backend ABC, extension-based auto-detection
 - **`_json_backend.py`**, **`_toml_backend.py`**, **`_yaml_backend.py`**, **`_hdf5_backend.py`** — Storage backends
 - **`_migration.py`** — Declarative + imperative migration system
-- **`_lazy.py`** — Lazy HDF5 array loading via dynamic subclass
+- **`_lazy.py`** — Lazy HDF5 loading: `LazyArray`, `LazyArrayList`, `LazyArrayDict`, dynamic subclass
 - **`_api.py`** — `save()`, `load()`, `loadDynamic()` entry points
 - **`errors.py`** — Exception hierarchy (`VersionableError` and subclasses)
 - **`hdf5.py`** — HDF5 submodule re-exports (compression presets)
@@ -171,3 +171,5 @@ Key design decisions:
 - Hash validated at class definition time (import time)
 - Versionable types use their serialization name (not module path) in hashes — stable across file moves
 - `save()`/`load()` accessed via qualified import (`import versionable`), not direct import
+- `Backend.save()` receives raw values + `cls`; each backend owns its serialization
+- HDF5 backend uses native type mapping (no JSON) with `__versionable__` metadata groups

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -124,8 +124,12 @@ on load. Every TOML field should have a default value.
 
 ### HDF5 Details
 
-Arrays are lazy-loaded by default — `load()` returns instantly even for multi-gigabyte files. Accessing an array field
-triggers the disk read.
+Every field maps to a native HDF5 construct — no JSON in the file. Scalars become attributes, arrays become datasets,
+nested Versionables become subgroups with a `__versionable__` metadata group, and `list[np.ndarray]` /
+`dict[str, np.ndarray]` become groups of datasets.
+
+Arrays and array collections are lazy-loaded by default — `load()` returns instantly even for multi-gigabyte files.
+Accessing an array field or indexing into a `list[np.ndarray]` triggers the disk read.
 
 ```python
 from versionable.hdf5 import ZSTD_DEFAULT, GZIP_DEFAULT
@@ -390,9 +394,12 @@ from versionable import Backend, registerBackend
 class MsgPackBackend(Backend):
     nativeTypes: set[type] = set()
 
-    def save(self, fields: dict, meta: dict, path, **kwargs) -> None: ...
+    def save(self, fields: dict, meta: dict, path, *, cls: type, **kwargs) -> None: ...
     def load(self, path) -> tuple[dict, dict]: ...
 
 
 registerBackend([".msgpack"], MsgPackBackend)
 ```
+
+The `save()` method receives raw (unserialized) field values and the Versionable class. Call `serialize()` internally
+for dict-based formats, or handle type dispatch directly for binary formats.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -51,7 +51,7 @@ channels:
   - 0
   - 1
   - 2
-__meta__:
+__versionable__:
   __OBJECT__: SensorConfig
   __VERSION__: 1
   __HASH__: 9d6951
@@ -59,8 +59,8 @@ __meta__:
 
 Both `.yaml` and `.yml` extensions are supported.
 
-Metadata is stored in a `__meta__` mapping at the end of the file — your data comes first, schema metadata stays out of
-the way.
+Metadata is stored in a `__versionable__` mapping at the end of the file — your data comes first, schema metadata stays
+out of the way.
 
 ### Missing fields
 
@@ -83,7 +83,7 @@ sampleRate_Hz: 120000
 # - 0
 # - 1
 # - 2
-__meta__:
+__versionable__:
   __OBJECT__: SensorConfig
   __VERSION__: 1
   __HASH__: 9d6951
@@ -131,7 +131,7 @@ name = "probe-A"
 sampleRate_Hz = 120000
 channels = [0, 1, 2]
 
-[__meta__]
+[__versionable__]
 __OBJECT__ = "SensorConfig"
 __VERSION__ = 1
 __HASH__ = "9d6951"
@@ -176,7 +176,7 @@ The saved TOML looks like:
 ```toml
 name = "worker"
 
-[__meta__]
+[__versionable__]
 __OBJECT__ = "WorkerConfig"
 __VERSION__ = 1
 __HASH__ = "8bdfa7"
@@ -203,7 +203,7 @@ name = "probe-A"
 sampleRate_Hz = 120000
 # channels = [0, 1, 2]
 
-[__meta__]
+[__versionable__]
 __OBJECT__ = "SensorConfig"
 __VERSION__ = 1
 __HASH__ = "9d6951"

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -256,8 +256,27 @@ rec = Recording(name="capture-1", sampleRate_Hz=240000, data=np.random.rand(1_00
 versionable.save(rec, "recording.h5")
 ```
 
-Arrays are stored as compressed HDF5 datasets. Scalar fields (`str`, `int`, `float`, etc.) are stored as dataset
-attributes and are always loaded immediately.
+Every field maps to a native HDF5 construct:
+
+| Python type                                           | HDF5 representation                            |
+| ----------------------------------------------------- | ---------------------------------------------- |
+| `int`, `float`, `bool`, `str`                         | Scalar attribute                               |
+| `np.ndarray`                                          | Dataset (compressed)                           |
+| `list[int]`, `list[float]`, `list[str]`, `list[bool]` | 1-D dataset                                    |
+| `list[np.ndarray]`                                    | Group of integer-keyed datasets                |
+| `dict[str, np.ndarray]`                               | Group of named datasets                        |
+| Nested `Versionable`                                  | Subgroup with `__versionable__` metadata group |
+| `list[Versionable]`                                   | Group of integer-keyed subgroups               |
+| `None`                                                | `h5py.Empty` attribute                         |
+| `Enum`                                                | Attribute (stores `.value`)                    |
+| Converted types (datetime, Path, etc.)                | Attribute (converter output)                   |
+
+Metadata (`__OBJECT__`, `__VERSION__`, `__HASH__`) is stored in a `__versionable__` child group at the root and inside
+each nested Versionable subgroup. This distinguishes Versionable groups from plain collection groups. `__FORMAT__` is
+reserved in this group for future versionable versioning.
+
+Files are readable with h5dump, HDFView, MATLAB, or any HDF5-compatible tool. Reconstructing exact Python types (e.g.,
+distinguishing `list[float]` from `np.ndarray`) requires the class's type annotations.
 
 ### Compression
 
@@ -321,13 +340,23 @@ versionable.save(rec, "recording.h5", compression=GZIP_DEFAULT)
 ### Lazy Loading
 
 By default, array fields are not read from disk until first access. This means `load()` returns almost instantly even
-for large files — the file handle stays open in the background and the array is fetched only when your code actually
-uses it:
+for large files — the array is fetched only when your code actually uses it:
 
 ```python
 loaded = versionable.load(Recording, "recording.h5")
 loaded.name    # Loaded immediately (scalar)
 loaded.data    # Read from disk on first access, then cached
+```
+
+Lazy loading also works per-element for collection fields:
+
+- **`list[np.ndarray]`** — returns a `LazyArrayList` where each element loads on indexing or iteration
+- **`dict[str, np.ndarray]`** — returns a `LazyArrayDict` where each value loads on key access
+
+```python
+loaded = versionable.load(Experiment, "experiment.h5")
+loaded.traces[0]         # Loads only the first trace
+loaded.channels["ch0"]   # Loads only channel "ch0"
 ```
 
 Lazy loading is particularly useful when you have many recordings on disk and only need to inspect metadata (name,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ The YAML file on disk looks like:
 ```yaml
 name: experiment-A
 value: 9.81
-__meta__:
+__versionable__:
   __OBJECT__: MyConfig
   __VERSION__: 1
   __HASH__: 4b7866

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -37,7 +37,7 @@ A v1 file on disk:
 title: batch-processor
 debug: false
 retries: 5
-__meta__:
+__versionable__:
   __OBJECT__: WorkerConfig
   __VERSION__: 1
   __HASH__: 5556c8

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -1,0 +1,245 @@
+# Native HDF5 Storage (Eliminate JSON)
+
+## Problem
+
+The HDF5 backend currently bundles all non-array fields into a single `__scalars__` JSON attribute:
+
+```python
+# Current _writeGroup behavior
+scalars: dict[str, Any] = {}
+for key, value in fields.items():
+    if isinstance(value, np.ndarray):
+        group.create_dataset(key, data=value, **datasetKwargs)
+    elif isinstance(value, dict) and "__OBJECT__" in value:
+        _writeNestedGroup(group, key, value, comp)
+    else:
+        scalars[key] = value                           # ← everything else
+if scalars:
+    group.attrs["__scalars__"] = json.dumps(scalars)   # ← one big JSON blob
+```
+
+This defeats the purpose of using HDF5:
+
+- **No individual field access** — can't read or update one scalar without parsing the whole blob.
+- **No type fidelity** — `float` becomes JSON `number`, `int` becomes JSON `number`, bools and
+  None are coerced through JSON round-trips.
+- **No interop** — other tools (MATLAB, HDFView, h5dump) see a single opaque JSON string.
+- **`list[np.ndarray]` is base64-encoded** — each array becomes a `{"__ndarray__": true, "data": "..."}` dict
+  inside the JSON blob, losing compression, lazy loading, and direct dataset access.
+- **Blocks save-as-you-go** — can't incrementally update a JSON blob efficiently.
+
+## Goal
+
+Every field maps to a native HDF5 construct. No JSON anywhere in `.h5` files. The file should be
+human-readable in HDFView / h5dump and accessible from any HDF5-compatible tool.
+
+## Native Type Mapping
+
+| Python type | HDF5 representation | Notes |
+|---|---|---|
+| `int` | Scalar attribute (int64) | |
+| `float` | Scalar attribute (float64) | |
+| `bool` | Scalar attribute (bool) | h5py handles this natively |
+| `str` | Scalar attribute (variable-length string) | |
+| `np.ndarray` | Dataset (with compression) | Unchanged from today |
+| `list[int]`, `list[float]` | 1-D dataset | Numeric lists stored as arrays |
+| `list[bool]` | 1-D dataset (bool) | |
+| `list[str]` | 1-D dataset (variable-length string) | h5py supports this |
+| `list[np.ndarray]` | Group of numbered datasets | `traces/0`, `traces/1`, … |
+| `dict[str, np.ndarray]` | Group of named datasets | `channels/ch0`, `channels/ch1`, … |
+| Nested `Versionable` | Subgroup with `__versionable__` child group | |
+| `list[Versionable]` | Group of numbered subgroups, each with `__versionable__` | |
+| `Enum` | Attribute (store `.value`) | Value is int or str |
+| `None` | Attribute with `h5py.Empty("f")` | Native HDF5 null; detected via `isinstance` on read |
+| Converted types (datetime, Path, etc.) | Attribute (converter output) | String or numeric |
+
+### Distinguishing Groups
+
+Groups are used for three purposes, distinguished by the presence of a `__versionable__` child group:
+
+| Has `__versionable__` child group? | Meaning |
+|---|---|
+| Yes | Versionable object; `__versionable__` holds `__OBJECT__`, `__VERSION__`, `__HASH__` (+ `__FORMAT__` reserved for future use) |
+| No | Collection group (list or dict); type determined from the parent class's field annotations |
+
+No type marker attributes are stored on collection groups. The deserializer always has the class's type
+annotations available and uses them to determine how to reconstruct the group (numbered entries → `list`,
+named entries → `dict`).
+
+### Unsupported Types
+
+Some types don't have clean HDF5 representations:
+
+- `dict[str, list[float]]` — group of datasets (each value is a 1-D dataset)
+- `list[dict[str, int]]` — no natural mapping; would need compound datasets or nested groups
+- Deeply nested mixed collections — arbitrarily complex trees
+
+**Approach:** Support the common cases in the mapping table above. For unsupported types, raise a clear
+error at save time pointing the user to restructure their data or use a dict-based backend (JSON/YAML).
+We can expand support incrementally based on real usage.
+
+## Target File Layout
+
+```text
+experiment.h5
+├── group: __versionable__/
+│   ├── attr: __OBJECT__ = "Experiment"
+│   ├── attr: __VERSION__ = 1
+│   └── attr: __HASH__ = "a1b2c3"
+├── attr:  name = "baseline"
+├── attr:  sampleRate_Hz = 48000.0
+├── dataset: timestamps  [shape=(3,), dtype=float64]
+└── group: traces/
+    ├── dataset: 0  [shape=(1024,), dtype=float64, zstd]
+    ├── dataset: 1  [shape=(1024,), dtype=float64, zstd]
+    └── dataset: 2  [shape=(1024,), dtype=float64, zstd]
+```
+
+## Serialization Architecture
+
+### Current Flow (Problem)
+
+```text
+save(obj, path)
+  → serialize(value, fieldType, nativeTypes={ndarray})  # generic dict-oriented serializer
+  → backend.save(serializedDict, meta, path)            # backend gets pre-serialized data
+```
+
+The backend receives a flat dict of already-serialized values. It doesn't know the original field types,
+so it can't distinguish `list[np.ndarray]` (→ group of datasets) from `list[dict]` (→ unsupported). It
+just sees a Python list and dumps it to JSON.
+
+### Proposed Flow
+
+```text
+save(obj, path)
+  → backend.save(rawValues, meta, path, cls=type(obj))
+```
+
+Every backend receives **raw field values** and the **Versionable class**. Each backend decides how
+to serialize for its format:
+
+- `_api.py` no longer calls `serialize()` — it passes raw values and the class to the backend.
+- Dict-based backends (JSON, YAML, TOML) call `serialize()` internally at the start of their
+  `save()` method, resolving field types from the class. This is a one-line change per backend.
+- The HDF5 backend resolves field types from the class and does its own type dispatch.
+- Converted types (datetime, Enum, etc.) are resolved by each backend using the same converter
+  registry.
+
+This keeps `_api.py` simple (no conditional paths) and gives each backend full control over how
+data is represented.
+
+### Backend ABC Change
+
+```python
+class Backend(ABC):
+    nativeTypes: ClassVar[set[type]] = set()
+
+    @abstractmethod
+    def save(
+        self,
+        fields: dict[str, Any],
+        meta: dict[str, Any],
+        path: Path,
+        *,
+        cls: type,                                     # new, required
+        **kwargs: Any,
+    ) -> None: ...
+```
+
+All backends receive `cls`. Dict-based backends use it to resolve field types for `serialize()`;
+the HDF5 backend uses it for native type dispatch.
+
+## Implementation Plan
+
+### 1. Refactor Backend Interface (commit: pure refactor, no behavior change)
+
+- Add required `cls` parameter to `Backend.save()`.
+- Update `save()` in `_api.py`: pass raw values + the class instead of calling `serialize()`.
+- Update dict-based backends (JSON, YAML, TOML) to call `serialize()` internally in their
+  `save()` methods, resolving field types from `cls`.
+- Run full existing test suite to confirm no regressions.
+
+### 2. Write Path (`_hdf5_backend.py`)
+
+- Resolve field types from `cls` and dispatch each field to the appropriate HDF5 construct.
+- Rewrite `_writeGroup()` to dispatch on field type:
+  - Primitives → `group.attrs[name] = value`
+  - `np.ndarray` → `group.create_dataset(name, data=value, **comp)`
+  - `None` → `group.attrs[name] = h5py.Empty("f")`
+  - `list[numeric]` / `list[str]` / `list[bool]` → `group.create_dataset(name, data=value)`
+  - `list[np.ndarray]` → create subgroup with integer-keyed datasets (`0`, `1`, …)
+  - `dict[str, np.ndarray]` → create subgroup with named datasets
+  - `Versionable` → create subgroup with a `__versionable__` child group holding metadata attrs
+  - `list[Versionable]` → create subgroup with integer-keyed subgroups, each with `__versionable__`
+  - Enum → `group.attrs[name] = value.value`
+  - Converted types → apply converter, write attribute
+- **Recursive write:** The write path operates on live Versionable instances, not pre-serialized
+  dicts. When a field is a nested Versionable, the writer resolves its metadata and field types
+  from the class, then recursively writes each of its fields as native HDF5 constructs. The same
+  applies to `list[Versionable]` — each element is a live instance whose fields must be
+  recursively written. This handles arbitrarily deep nesting (e.g., a Versionable containing a
+  `list[Versionable]` where each element contains arrays, nested Versionables, etc.).
+- Write metadata (`__OBJECT__`, `__VERSION__`, `__HASH__`) into a `__versionable__` child group at the root.
+- Remove all `json.dumps` from write path.
+
+### 3. Read Path (`_hdf5_backend.py`)
+
+- Reconstruct fields from attributes + datasets + groups:
+  - Scalar attributes → field values directly.
+  - Datasets → `np.ndarray` or `list[numeric]` (distinguished by the class's field type).
+  - Groups with `__versionable__` child → nested Versionable; read `__versionable__` attrs for metadata, recurse for fields.
+  - Groups without `__versionable__` → collection; the class's field type determines `list` vs `dict` reconstruction.
+
+### 4. Lazy Loading Updates
+
+- `loadLazy` needs to handle the new group types:
+  - `list[np.ndarray]` group → could return a `LazyList` where each element is a `LazyArray`.
+  - Individual scalar attributes → always eagerly loaded (they're tiny).
+  - `list[float]` dataset → eagerly loaded (small) or lazy like any other dataset.
+
+### 5. Deserialization
+
+- The HDF5 backend returns values that are closer to their final Python types (not JSON-derived).
+- `deserialize()` still runs on the loaded data (to handle Enum reconstruction, converter types, etc.),
+  but the data is no longer coming from JSON — it's native Python/numpy types.
+- May need small adjustments to `deserialize()` to handle numpy scalars (`np.int64` → `int`, etc.).
+
+### 6. `loadDynamic` Support
+
+- `loadDynamic()` reads `__OBJECT__` from `__versionable__`, looks up the class in the registry,
+  then has `cls` available for type-aware reconstruction. No special handling needed.
+
+### 7. Migration Considerations
+
+- Migrations transform raw field dicts and must see the same types regardless of backend.
+- The HDF5 backend's `load()` normalizes values to standard Python types: `np.int64` → `int`,
+  `np.float64` → `float`, 1-D datasets → `list`, etc. The only native type that passes through
+  is `np.ndarray` (same as today).
+- This keeps migrations backend-agnostic — the HDF5-native layout is purely a file format concern.
+
+### 8. Tests
+
+- Roundtrip for every type in the mapping table.
+- `list[np.ndarray]` with varying shapes and dtypes.
+- `dict[str, np.ndarray]` roundtrip.
+- `list[Versionable]` roundtrip.
+- Lazy loading: per-element lazy for `list[np.ndarray]`.
+- Error case: unsupported nested type raises clear error.
+- Compression still works with all new storage patterns.
+- Nested Versionable containing array collections.
+
+## Design Decisions
+
+1. **Integer keys for list groups.** Bare integers (`0`, `1`, …) without `track_order`. On read,
+   keys are sorted numerically (`sorted(group.keys(), key=int)`).
+
+2. **No type hints for converted types.** The class's type annotations are sufficient at load time.
+   External tools will see the stored value (e.g., a string for datetime) without type context.
+
+3. **`None` via `h5py.Empty`.** HDF5 attributes can't store `None`. Fields with value `None` are
+   stored as `group.attrs[name] = h5py.Empty("f")` — a native HDF5 null. On read, detected via
+   `isinstance(value, h5py.Empty)` and converted back to `None`. This is needed because omitting
+   the attribute would fall back to the dataclass default, which may not be `None`.
+   (`skipDefaults` still works: if the default is `None` and the value is `None`, the field is
+   omitted entirely — no empty attribute written.)

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The HDF5 backend currently bundles all non-array fields into a single `__scalars__` JSON attribute:
+The HDF5 backend previously bundled all non-array fields into a single `__scalars__` JSON attribute:
 
 ```python
 # Current _writeGroup behavior
@@ -18,7 +18,7 @@ if scalars:
     group.attrs["__scalars__"] = json.dumps(scalars)   # ← one big JSON blob
 ```
 
-This defeats the purpose of using HDF5:
+This defeated the purpose of using HDF5:
 
 - **No individual field access** — can't read or update one scalar without parsing the whole blob.
 - **No type fidelity** — `float` becomes JSON `number`, `int` becomes JSON `number`, bools and
@@ -99,7 +99,7 @@ experiment.h5
 
 ## Serialization Architecture
 
-### Current Flow (Problem)
+### Previous Flow (Problem)
 
 ```text
 save(obj, path)
@@ -107,11 +107,11 @@ save(obj, path)
   → backend.save(serializedDict, meta, path)            # backend gets pre-serialized data
 ```
 
-The backend receives a flat dict of already-serialized values. It doesn't know the original field types,
-so it can't distinguish `list[np.ndarray]` (→ group of datasets) from `list[dict]` (→ unsupported). It
-just sees a Python list and dumps it to JSON.
+The backend received a flat dict of already-serialized values. It didn't know the original field types,
+so it couldn't distinguish `list[np.ndarray]` (→ group of datasets) from `list[dict]` (→ unsupported). It
+just saw a Python list and dumped it to JSON.
 
-### Proposed Flow
+### New Flow
 
 ```text
 save(obj, path)
@@ -164,34 +164,36 @@ the HDF5 backend uses it for native type dispatch.
 
 ### 2. Write Path (`_hdf5_backend.py`)
 
-- Resolve field types from `cls` and dispatch each field to the appropriate HDF5 construct.
-- Rewrite `_writeGroup()` to dispatch on field type:
-  - Primitives → `group.attrs[name] = value`
-  - `np.ndarray` → `group.create_dataset(name, data=value, **comp)`
-  - `None` → `group.attrs[name] = h5py.Empty("f")`
-  - `list[numeric]` / `list[str]` / `list[bool]` → `group.create_dataset(name, data=value)`
-  - `list[np.ndarray]` → create subgroup with integer-keyed datasets (`0`, `1`, …)
-  - `dict[str, np.ndarray]` → create subgroup with named datasets
-  - `Versionable` → create subgroup with a `__versionable__` child group holding metadata attrs
-  - `list[Versionable]` → create subgroup with integer-keyed subgroups, each with `__versionable__`
-  - Enum → `group.attrs[name] = value.value`
-  - Converted types → apply converter, write attribute
-- **Recursive write:** The write path operates on live Versionable instances, not pre-serialized
-  dicts. When a field is a nested Versionable, the writer resolves its metadata and field types
-  from the class, then recursively writes each of its fields as native HDF5 constructs. The same
-  applies to `list[Versionable]` — each element is a live instance whose fields must be
-  recursively written. This handles arbitrarily deep nesting (e.g., a Versionable containing a
-  `list[Versionable]` where each element contains arrays, nested Versionables, etc.).
-- Write metadata (`__OBJECT__`, `__VERSION__`, `__HASH__`) into a `__versionable__` child group at the root.
-- Remove all `json.dumps` from write path.
+- `_writeValue()` does fully recursive type dispatch on each field:
+  - `None` → `h5py.Empty("f")` attribute
+  - `np.ndarray` → dataset with compression
+  - `Versionable` → subgroup with `__versionable__` metadata, recurse for fields
+  - `Enum` → attribute (`.value`)
+  - Scalar primitives (`int`, `float`, `str`, `bool`) → attribute
+  - Converted types (datetime, Path, etc.) → apply converter, write attribute
+  - `list`/`set`/`frozenset`/`tuple` of scalars → 1-D dataset
+  - `list`/`set`/`frozenset`/`tuple` of non-scalars → group with integer keys, recurse
+  - `dict[K, V]` → group with percent-encoded keys, recurse for values
+- Dict keys are percent-encoded via `_keyToStr()`: `/` → `%2F`, `%` → `%25`,
+  bare `.` → `%2E`. Null bytes and empty keys are rejected. Decoded on read via
+  `urllib.parse.unquote()`.
+- Nested Versionable writes operate on live instances, not pre-serialized dicts.
+  Recursion handles arbitrarily deep nesting (e.g., `dict[str, Versionable]`
+  where each Versionable contains `list[np.ndarray]`).
+- Metadata into `__versionable__` child group. No `json.dumps` anywhere.
 
 ### 3. Read Path (`_hdf5_backend.py`)
 
-- Reconstruct fields from attributes + datasets + groups:
-  - Scalar attributes → field values directly.
-  - Datasets → `np.ndarray` or `list[numeric]` (distinguished by the class's field type).
-  - Groups with `__versionable__` child → nested Versionable; read `__versionable__` attrs for metadata, recurse for fields.
-  - Groups without `__versionable__` → collection; the class's field type determines `list` vs `dict` reconstruction.
+- `_readFields()` reconstructs fields with recursive type dispatch:
+  - Scalar attributes → Python primitives (`np.int64` → `int`, etc. via `_readAttr()`)
+  - Datasets → `np.ndarray` or `list[scalar]` (via `_readDataset()`, type from class annotation)
+  - Groups with `__versionable__` → `_readVersionableGroup()`, which resolves the class from the
+    declared type annotation first, falling back to `_resolveClass()` by `__OBJECT__` name
+  - Groups without `__versionable__` → `_readGroup()` with recursive dispatch through
+    `_readSequenceGroup()`, `_readDictGroup()`, `_readChild()`
+- Dict keys are decoded from percent-encoding via `_strToKey()` using `urllib.parse.unquote()`
+  and converted back to the original type (int, float, Enum, etc.) from the type annotation.
+- `load()` and `loadLazy()` both raise `BackendError` when `_resolveClass()` returns `None`.
 
 ### 4. Lazy Loading Updates
 
@@ -239,9 +241,10 @@ helpers** lazy-aware when building those dicts:
 
 #### Sentinel recognition
 
-`_types.py` shouldn't import `_lazy.py` directly (to avoid coupling). Instead, check for a
-`_isLazySentinel` attribute or use a simple type check against a base class / protocol. The
-simplest approach: `_lazy.py` adds a `isLazySentinel(value)` function that `_types.py` calls.
+`_types.py` must not import `_lazy.py` at module level (it would pull in `h5py` on systems
+without it). Instead, each sentinel class has `_isLazySentinel = True`. Detection is via
+`getattr(value, "_isLazySentinel", False)`. The `makeLazyInstance` import is deferred inside
+the `if lazyFields:` block that only runs in HDF5 paths.
 
 #### What stays the same
 
@@ -272,14 +275,25 @@ simplest approach: `_lazy.py` adds a `isLazySentinel(value)` function that `_typ
 
 ### 8. Tests
 
-- Roundtrip for every type in the mapping table.
-- `list[np.ndarray]` with varying shapes and dtypes.
-- `dict[str, np.ndarray]` roundtrip.
-- `list[Versionable]` roundtrip.
-- Lazy loading: per-element lazy for `list[np.ndarray]`.
-- Error case: unsupported nested type raises clear error.
-- Compression still works with all new storage patterns.
-- Nested Versionable containing array collections.
+- **Cross-backend kitchen sink** — every common type (str, int, float, bool, Enum, datetime,
+  date, timedelta, Path, UUID, Literal, set, frozenset, tuple, dict with int/str keys, nested
+  dict[str, list[float]], nested Versionable, list[Versionable]) roundtripped through all 4
+  backends with exact type and value assertions.
+- **Numpy dtypes** — 13 dtypes × 4 backends, plus 2D, 3D, and empty array shape preservation.
+- **HDF5-specific** — native attribute storage (no `__scalars__`), `__versionable__` metadata
+  layout, compression algorithms, file extensions.
+- **Lazy loading** — per-element lazy for `list[np.ndarray]` (`LazyArrayList`) and
+  `dict[str, np.ndarray]` (`LazyArrayDict`), preload, metadataOnly, slicing, iteration,
+  lazy dict with percent-encoded keys and cache state verification.
+- **Recursive lazy loading** — arrays inside nested Versionables get `LazyArray` sentinels;
+  deeply nested `dict[str, Versionable]` with `list[np.ndarray]` fields verified lazy at
+  two levels deep; `preload="*"` eagerly loads everything.
+- **Dict key edge cases** — `/`, `%2F` literal, `.` all roundtrip correctly via percent-encoding.
+- **Error cases** — missing file, unregistered class in `load()` and `loadLazy()`.
+- **None handling** — `None` vs default, optional fields, TOML omit behavior.
+- **Empty collections** — empty lists, empty `list[np.ndarray]`, empty `dict[str, np.ndarray]`.
+- **No JSON anywhere** — recursive assertion that no attribute in the file contains JSON strings.
+- **CI** — all tests gated on HDF5 availability for minimal (no h5py) environments.
 
 ## Design Decisions
 
@@ -295,3 +309,11 @@ simplest approach: `_lazy.py` adds a `isLazySentinel(value)` function that `_typ
    the attribute would fall back to the dataclass default, which may not be `None`.
    (`skipDefaults` still works: if the default is `None` and the value is `None`, the field is
    omitted entirely — no empty attribute written.)
+
+4. **Dict key percent-encoding.** HDF5 interprets `/` as a path separator and `.` as the current
+   group. Keys are encoded on write (`/` → `%2F`, `%` → `%25`, bare `.` → `%2E`) and decoded
+   on read via `urllib.parse.unquote()`. Null bytes and empty keys are rejected.
+
+5. **Strict class resolution.** Both `load()` and `loadLazy()` raise `BackendError` when the
+   file's `__OBJECT__` class can't be resolved. Silently falling back to `fieldTypes = {}` would
+   cause arrays to be misinterpreted as lists and vice versa.

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -195,10 +195,60 @@ the HDF5 backend uses it for native type dispatch.
 
 ### 4. Lazy Loading Updates
 
-- `loadLazy` needs to handle the new group types:
-  - `list[np.ndarray]` group → could return a `LazyList` where each element is a `LazyArray`.
-  - Individual scalar attributes → always eagerly loaded (they're tiny).
-  - `list[float]` dataset → eagerly loaded (small) or lazy like any other dataset.
+Lazy loading is **recursive** — it applies at every level of the object tree, not just the root.
+
+#### Current architecture
+
+`loadLazy` returns a flat `(fields, meta, lazyFields)` tuple. `_api.py` skips `deserialize()` for
+fields in `lazyFields` and wraps the instance with `makeLazyInstance`, which installs a
+`__getattribute__` override that resolves `LazyArray` sentinels on first access.
+
+The problem: nested Versionable groups are read eagerly via `_readGroup` → `_readVersionableGroup`,
+which loads everything including arrays. Lazy loading only applies to top-level fields.
+
+#### Design
+
+The read path already reconstructs nested Versionables as dicts with `__OBJECT__` metadata (which
+`_deserializeVersionable` in `_types.py` turns into instances). The fix is to make the **HDF5 read
+helpers** lazy-aware when building those dicts:
+
+1. **`_readFields` accepts a lazy context** — a `_LazyContext` dataclass holding `path`,
+   `preloadAll`, `preloadSet`, and `metadataOnly`. When `None`, everything is eager (used by
+   `Backend.load()`). When present, the same lazy logic that `loadLazy` applies to the root is
+   applied recursively at every level.
+
+2. **`_readVersionableGroup` propagates the lazy context** — it passes the context down to
+   `_readFields`, so nested Versionable objects get the same lazy treatment as the root.
+
+3. **`_readFields` with lazy context** classifies each child the same way `loadLazy` does today:
+   - `np.ndarray` dataset → `LazyArray(path, fullDatasetPath)` (uses the full HDF5 path)
+   - Scalar dataset (`list[float]`, etc.) → eager
+   - `list[np.ndarray]` / `dict[str, np.ndarray]` group → `LazyArrayList` / `LazyArrayDict`
+   - Nested Versionable group → recurse with the same lazy context
+   - Scalar attributes → eager
+
+4. **`_api.py` deserialization handles lazy sentinels at any depth** — `_deserializeVersionable`
+   in `_types.py` already iterates fields and calls `deserialize()`. It needs to:
+   - Skip deserialization for `LazyArray` / `LazyArrayList` / `LazyArrayDict` / `ArrayNotLoaded`
+     sentinels (pass them through as-is)
+   - Call `makeLazyInstance` on the nested instance if it has lazy fields
+
+5. **`loadLazy` simplifies** — instead of duplicating the field classification logic, it calls
+   `_readFields(group, fieldTypes, lazyContext)` and collects `lazyFields` from the result.
+   The root-level lazy field tracking is just for the `makeLazyInstance` call in `_api.py`.
+
+#### Sentinel recognition
+
+`_types.py` shouldn't import `_lazy.py` directly (to avoid coupling). Instead, check for a
+`_isLazySentinel` attribute or use a simple type check against a base class / protocol. The
+simplest approach: `_lazy.py` adds a `isLazySentinel(value)` function that `_types.py` calls.
+
+#### What stays the same
+
+- `LazyArray`, `LazyArrayList`, `LazyArrayDict`, `ArrayNotLoaded` — unchanged
+- `makeLazyInstance` / `_getLazyClass` — unchanged, just applied at every Versionable level
+- `preload` / `metadataOnly` semantics — unchanged, just applied recursively
+- The write path — unchanged (lazy loading is read-only)
 
 ### 5. Deserialization
 

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -35,23 +35,38 @@ human-readable in HDFView / h5dump and accessible from any HDF5-compatible tool.
 
 ## Native Type Mapping
 
-| Python type | HDF5 representation | Notes |
+The write/read paths use **fully recursive type dispatch**. Any value is classified into one of
+three categories, and collections recurse for their elements:
+
+| Category | Types | HDF5 representation |
 |---|---|---|
-| `int` | Scalar attribute (int64) | |
-| `float` | Scalar attribute (float64) | |
-| `bool` | Scalar attribute (bool) | h5py handles this natively |
-| `str` | Scalar attribute (variable-length string) | |
-| `np.ndarray` | Dataset (with compression) | Unchanged from today |
-| `list[int]`, `list[float]` | 1-D dataset | Numeric lists stored as arrays |
-| `list[bool]` | 1-D dataset (bool) | |
-| `list[str]` | 1-D dataset (variable-length string) | h5py supports this |
-| `list[np.ndarray]` | Group of numbered datasets | `traces/0`, `traces/1`, … |
-| `dict[str, np.ndarray]` | Group of named datasets | `channels/ch0`, `channels/ch1`, … |
-| Nested `Versionable` | Subgroup with `__versionable__` child group | |
-| `list[Versionable]` | Group of numbered subgroups, each with `__versionable__` | |
-| `Enum` | Attribute (store `.value`) | Value is int or str |
-| `None` | Attribute with `h5py.Empty("f")` | Native HDF5 null; detected via `isinstance` on read |
-| Converted types (datetime, Path, etc.) | Attribute (converter output) | String or numeric |
+| Scalar | `int`, `float`, `bool`, `str`, `Enum`, converted types, `None` | Attribute |
+| Array | `np.ndarray` | Dataset (compressed) |
+| Scalar sequence | `list[scalar]`, `set[scalar]`, `tuple[scalar, ...]`, `frozenset[scalar]` | 1-D dataset |
+| Collection of non-scalars | `list[T]`, `set[T]`, `tuple[T, ...]`, `frozenset[T]` | Group with integer keys, recurse for each element |
+| Dict | `dict[K, V]` | Group with string-converted keys, recurse for each value |
+| Versionable | Nested `Versionable` | Subgroup with `__versionable__` metadata group, recurse for fields |
+
+`None` is stored as `h5py.Empty("f")` — a native HDF5 null.
+
+### Dict Key Conversion
+
+HDF5 group keys are always strings. Non-string dict keys are converted to strings on write and
+back to the original type on read using the type annotation:
+
+- `int` → `str(42)` → `int("42")`
+- `float` → `str(3.14)` → `float("3.14")`
+- `Enum` → `str(value)` → reconstruct from value
+- Converted types (UUID, Path, etc.) → use the converter registry
+- `str` → identity
+
+### Recursive Nesting
+
+Because the dispatch is recursive, arbitrarily nested structures work naturally:
+
+- `dict[str, list[float]]` — group of 1-D datasets
+- `list[dict[str, int]]` — group of subgroups, each with int attributes
+- `dict[int, dict[str, Versionable]]` — groups all the way down
 
 ### Distinguishing Groups
 
@@ -60,23 +75,10 @@ Groups are used for three purposes, distinguished by the presence of a `__versio
 | Has `__versionable__` child group? | Meaning |
 |---|---|
 | Yes | Versionable object; `__versionable__` holds `__OBJECT__`, `__VERSION__`, `__HASH__` (+ `__FORMAT__` reserved for future versionable versioning) |
-| No | Collection group (list or dict); type determined from the parent class's field annotations |
+| No | Collection group (list, set, tuple, frozenset, or dict); type determined from the parent class's field annotations |
 
 No type marker attributes are stored on collection groups. The deserializer always has the class's type
-annotations available and uses them to determine how to reconstruct the group (numbered entries → `list`,
-named entries → `dict`).
-
-### Unsupported Types
-
-Some types don't have clean HDF5 representations:
-
-- `dict[str, list[float]]` — group of datasets (each value is a 1-D dataset)
-- `list[dict[str, int]]` — no natural mapping; would need compound datasets or nested groups
-- Deeply nested mixed collections — arbitrarily complex trees
-
-**Approach:** Support the common cases in the mapping table above. For unsupported types, raise a clear
-error at save time pointing the user to restructure their data or use a dict-based backend (JSON/YAML).
-We can expand support incrementally based on real usage.
+annotations available and uses them to determine how to reconstruct the group.
 
 ## Target File Layout
 

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -59,7 +59,7 @@ Groups are used for three purposes, distinguished by the presence of a `__versio
 
 | Has `__versionable__` child group? | Meaning |
 |---|---|
-| Yes | Versionable object; `__versionable__` holds `__OBJECT__`, `__VERSION__`, `__HASH__` (+ `__FORMAT__` reserved for future use) |
+| Yes | Versionable object; `__versionable__` holds `__OBJECT__`, `__VERSION__`, `__HASH__` (+ `__FORMAT__` reserved for future versionable versioning) |
 | No | Collection group (list or dict); type determined from the parent class's field annotations |
 
 No type marker attributes are stored on collection groups. The deserializer always has the class's type

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -126,13 +126,15 @@ class MyConfig(Versionable, version=1, hash="4b7866"):
 The following dunder keys are used internally by **`versionable`** and must not be used as field names or as keys in
 user-provided dict values:
 
-| Key           | Purpose                                                   |
-| ------------- | --------------------------------------------------------- |
-| `__OBJECT__`  | Serialization class name (stored in metadata)             |
-| `__VERSION__` | Schema version (stored in metadata)                       |
-| `__HASH__`    | Schema hash (stored in metadata)                          |
-| `__meta__`    | Metadata mapping in YAML and TOML files                   |
-| `__ndarray__` | Marks a dict as a serialized numpy array                  |
-| `__json__`    | YAML-only wrapper for values with no native YAML encoding |
+| Key               | Purpose                                                   |
+| ----------------- | --------------------------------------------------------- |
+| `__OBJECT__`      | Serialization class name (stored in metadata)             |
+| `__VERSION__`     | Schema version (stored in metadata)                       |
+| `__HASH__`        | Schema hash (stored in metadata)                          |
+| `__meta__`        | Metadata mapping in YAML and TOML files                   |
+| `__versionable__` | HDF5 metadata child group (holds `__OBJECT__`, etc.)      |
+| `__FORMAT__`      | Reserved for future versionable versioning                |
+| `__ndarray__`     | Marks a dict as a serialized numpy array (JSON/YAML/TOML) |
+| `__json__`        | YAML-only wrapper for values with no native YAML encoding |
 
 > ⚠️ **Warning:** Using any of these as a field name or dict key will cause incorrect serialization or deserialization.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -128,13 +128,13 @@ user-provided dict values:
 
 | Key               | Purpose                                                   |
 | ----------------- | --------------------------------------------------------- |
+| `__ndarray__`     | Marks a dict as a serialized numpy array (JSON/YAML/TOML) |
+| `__json__`        | YAML-only wrapper for values with no native YAML encoding |
+| `__versionable__` | Versionable metadata envelope                             |
 | `__OBJECT__`      | Serialization class name (stored in metadata)             |
 | `__VERSION__`     | Schema version (stored in metadata)                       |
 | `__HASH__`        | Schema hash (stored in metadata)                          |
-| `__meta__`        | Metadata mapping in YAML and TOML files                   |
-| `__versionable__` | HDF5 metadata child group (holds `__OBJECT__`, etc.)      |
 | `__FORMAT__`      | Reserved for future versionable versioning                |
-| `__ndarray__`     | Marks a dict as a serialized numpy array (JSON/YAML/TOML) |
-| `__json__`        | YAML-only wrapper for values with no native YAML encoding |
+| `__FORMAT_BE__`   | Reserved for future backend versioning                    |
 
-> ⚠️ **Warning:** Using any of these as a field name or dict key will cause incorrect serialization or deserialization.
+> ⚠️ **Warning:** Using any of these as a field name or dict key may cause incorrect serialization or deserialization.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -132,8 +132,8 @@ class SensorConfig(
 **Serialized fields:** annotated, non-private (no `_` prefix), non-`ClassVar`. Private fields, unannotated attributes,
 and `ClassVar` are excluded.
 
-**Reserved metadata keys (cannot be field names):** `__OBJECT__`, `__VERSION__`, `__HASH__`, `__meta__`, `__ndarray__`,
-`__json__`.
+**Reserved metadata keys (cannot be field names):** `__OBJECT__`, `__VERSION__`, `__HASH__`, `__versionable__`,
+`__ndarray__`, `__json__`.
 
 ### Type System
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -79,7 +79,9 @@ class Shape(Versionable, version=1, hash="..."):
 
 ## Numpy Arrays
 
-- **HDF5:** Stored as native compressed datasets with lazy loading by default. See [Backends](backends.md).
+- **HDF5:** Stored as native compressed datasets with lazy loading by default. `list[np.ndarray]` becomes a group of
+  integer-keyed datasets; `dict[str, np.ndarray]` becomes a group of named datasets. Both support per-element lazy
+  loading. See [Backends](backends.md).
 - **JSON / TOML:** Stored as base64-compressed npz blobs.
 - **YAML:** Stored as a `__json__` wrapper containing the base64-compressed npz blob as a JSON string.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -5069,7 +5069,7 @@ packages:
 - pypi: ./
   name: versionable
   version: 0.0.1.dev3
-  sha256: e1f6cb654c706ec15177450869e750c9c4150257bcb00dd5439366c183747b4a
+  sha256: cdb7c8e0fe14ba443bf87568b67a270c1561a23924f44a13e163ff49eed6028a
   requires_dist:
   - toml>=0.10
   - pyyaml>=6.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -5068,8 +5068,8 @@ packages:
   timestamp: 1767320173250
 - pypi: ./
   name: versionable
-  version: 0.0.1.dev3
-  sha256: cdb7c8e0fe14ba443bf87568b67a270c1561a23924f44a13e163ff49eed6028a
+  version: 0.0.1.dev4
+  sha256: dfae24653112a1091b2aad3cfea100258da9e7bedeaebd8b4ad7a6d2c1721338
   requires_dist:
   - toml>=0.10
   - pyyaml>=6.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,6 +20,8 @@ mdlint_check = "npx markdownlint-cli2 '**/*.md'"
 test = "pytest"
 cleanup = { depends-on = ["format", "ruff", "mypy", "pyright", "prettier", "mdlint"] }
 ci = { depends-on = ["format_check", "ruff_check", "mypy", "pyright", "prettier_check", "mdlint_check", "test"] }
+ci-minimal = { cmd = "pixi run -e minimal ci", description = "Run CI in minimal environment (no h5py)" }
+ci-all = { depends-on = ["ci", "ci-minimal"], description = "Run CI in all environments" }
 
 [dependencies]
 python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ignore = [
     "N812",     # lowercase imported as non-lowercase
     "N815",     # camelCase in class scope (project convention)
     "N816",     # camelCase in global scope (project convention)
+    "PLR0911",  # too many returns (type-dispatch functions)
     "PLR0912",
     "PLR0915",
     "PLR0913",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "versionable"
-version = "0.0.1.dev3"
+version = "0.0.1.dev4"
 description = "Versioned persistence for Python dataclasses with hash validation, declarative migrations, and pluggable backends"
 readme = "README.md"
 license = "MIT"

--- a/src/versionable/_api.py
+++ b/src/versionable/_api.py
@@ -120,7 +120,10 @@ def load[T: Versionable](
     lazyFields: set[str] = set()
     loadLazy = getattr(be, "loadLazy", None)
     if loadLazy is not None and (preload != "*" or metadataOnly):
-        rawFields, fileMeta, lazyFields = loadLazy(path, preload=preload, metadataOnly=metadataOnly)
+        rawFields, fileMeta, lazyFields = loadLazy(path, cls=cls, preload=preload, metadataOnly=metadataOnly)
+    elif loadLazy is not None:
+        # HDF5 with preload="*" — use loadLazy so cls is available for type dispatch
+        rawFields, fileMeta, lazyFields = loadLazy(path, cls=cls, preload="*", metadataOnly=False)
     else:
         rawFields, fileMeta = be.load(path)
 

--- a/src/versionable/_api.py
+++ b/src/versionable/_api.py
@@ -17,7 +17,7 @@ from typing import Any, TypeVar
 
 from versionable._backend import Backend, getBackend
 from versionable._base import Versionable, _resolveFields, metadata
-from versionable._types import deserialize, serialize
+from versionable._types import deserialize
 from versionable.errors import BackendError, UnknownFieldError, VersionError
 
 logger = logging.getLogger(__name__)
@@ -50,12 +50,12 @@ def save(
     path = Path(path)
     be = getBackend(path, explicit=backend)
 
-    meta = metadata(type(obj))
-    fields = _resolveFields(type(obj))
-    nativeTypes = be.nativeTypes
+    objType = type(obj)
+    meta = metadata(objType)
+    fields = _resolveFields(objType)
 
-    serializedFields: dict[str, Any] = {}
-    for fieldName, fieldType in fields.items():
+    rawFields: dict[str, Any] = {}
+    for fieldName in fields:
         value = getattr(obj, fieldName)
 
         # skip_defaults: omit fields at their default value
@@ -63,7 +63,7 @@ def save(
             import dataclasses
 
             # Versionable subclasses are always @dataclass; mypy/pyright can't prove that statically.
-            dcFields = {f.name: f for f in dataclasses.fields(type(obj))}  # type: ignore[arg-type]
+            dcFields = {f.name: f for f in dataclasses.fields(objType)}  # type: ignore[arg-type]
             if fieldName in dcFields:
                 dcField = dcFields[fieldName]
                 if dcField.default is not dataclasses.MISSING and value == dcField.default:
@@ -71,14 +71,14 @@ def save(
                 if dcField.default_factory is not dataclasses.MISSING and value == dcField.default_factory():
                     continue
 
-        serializedFields[fieldName] = serialize(value, fieldType, nativeTypes=nativeTypes)
+        rawFields[fieldName] = value
 
     metaDict = {
         "name": meta.name,
         "version": meta.version,
         "hash": meta.hash,
     }
-    be.save(serializedFields, metaDict, path, commentDefaults=commentDefaults, **kwargs)
+    be.save(rawFields, metaDict, path, cls=objType, commentDefaults=commentDefaults, **kwargs)
 
 
 def load[T: Versionable](

--- a/src/versionable/_backend.py
+++ b/src/versionable/_backend.py
@@ -20,9 +20,18 @@ class Backend(ABC):
         fields: dict[str, Any],
         meta: dict[str, Any],
         path: Path,
+        *,
+        cls: type,
         **kwargs: Any,
     ) -> None:
-        """Write serialized fields and metadata to *path*."""
+        """Write fields and metadata to *path*.
+
+        Args:
+            fields: Raw field values (not pre-serialized).
+            meta: Metadata dict with ``name``, ``version``, ``hash`` keys.
+            path: Output file path.
+            cls: The Versionable subclass, used to resolve field types.
+        """
 
     @abstractmethod
     def load(self, path: Path) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/versionable/_hash.py
+++ b/src/versionable/_hash.py
@@ -28,7 +28,7 @@ def computeHash(fields: dict[str, Any]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:6]
 
 
-def canonicalTypeName(tp: Any) -> str:  # noqa: PLR0911 — type-dispatch; many returns are inherent
+def canonicalTypeName(tp: Any) -> str:
     """Return a stable, canonical string representation of a type.
 
     This must be deterministic across Python versions.  It normalises

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -136,7 +136,22 @@ class Hdf5Backend(Backend):
                             # list[numeric], list[str], etc. — always eager
                             fields[key] = _readDataset(item, fieldType)
                     elif isinstance(item, h5py.Group):
-                        fields[key] = _readGroup(item, fieldType)
+                        if _VERSIONABLE_GROUP in item:
+                            # Nested Versionable — always eager
+                            fields[key] = _readGroup(item, fieldType)
+                        elif _isArrayCollectionField(fieldType):
+                            # list[ndarray] or dict[str, ndarray] — lazy per-element
+                            if metadataOnly:
+                                fields[key] = ArrayNotLoaded(key)
+                                lazyFields.add(key)
+                            elif preloadAll or key in preloadSet:
+                                fields[key] = _readGroup(item, fieldType)
+                            else:
+                                fields[key] = _makeLazyCollection(path, key, item, fieldType)
+                                lazyFields.add(key)
+                        else:
+                            # Other groups (list[Versionable], etc.) — eager
+                            fields[key] = _readGroup(item, fieldType)
 
                 # Read scalar attributes
                 for attrName in f.attrs:
@@ -168,7 +183,7 @@ def _writeFields(
         _writeField(group, name, value, fieldType, datasetKwargs, comp)
 
 
-def _writeField(  # noqa: PLR0911 — type dispatch; many returns are inherent
+def _writeField(
     group: h5py.Group,
     name: str,
     value: Any,
@@ -454,7 +469,7 @@ def _readDictGroup(group: h5py.Group, valType: Any) -> dict[str, Any]:
     return result
 
 
-def _readAttr(value: Any) -> Any:  # noqa: PLR0911 — type dispatch
+def _readAttr(value: Any) -> Any:
     """Convert an HDF5 attribute value to a Python value."""
     # h5py.Empty → None
     if isinstance(value, h5py.Empty):
@@ -486,6 +501,37 @@ def _resolveClass(objectName: str) -> type | None:
 
     registry = registeredClasses()
     return registry.get(objectName)
+
+
+def _isArrayCollectionField(fieldType: Any) -> bool:
+    """Check if a field type is list[ndarray] or dict[str, ndarray]."""
+    if fieldType is None:
+        return False
+    origin = typing.get_origin(fieldType)
+    args = typing.get_args(fieldType)
+    if not args:
+        return False
+    if origin is list:
+        return _isNdarrayType(args[0]) or args[0] is np.ndarray
+    if origin is dict:
+        valType = args[1] if len(args) > 1 else None
+        return valType is not None and (_isNdarrayType(valType) or valType is np.ndarray)
+    return False
+
+
+def _makeLazyCollection(path: Path, key: str, group: h5py.Group, fieldType: Any) -> Any:
+    """Create a LazyArrayList or LazyArrayDict for an array collection group."""
+    from versionable._lazy import LazyArrayDict, LazyArrayList
+
+    origin = typing.get_origin(fieldType)
+    if origin is list:
+        keys = sorted(group.keys(), key=int)
+        return LazyArrayList(path, key, keys)
+    if origin is dict:
+        keys = list(group.keys())
+        return LazyArrayDict(path, key, keys)
+    # Shouldn't get here — _isArrayCollectionField guards the call
+    return _readGroup(group, fieldType)
 
 
 def _isArrayField(fieldType: Any) -> bool:

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -416,7 +416,7 @@ def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
     """Read a group using recursive type dispatch."""
     # Versionable group: has __versionable__ child
     if _VERSIONABLE_GROUP in group:
-        return _readVersionableGroup(group)
+        return _readVersionableGroup(group, fieldType)
 
     # Collection group: determined by field type
     origin = typing.get_origin(fieldType)
@@ -435,8 +435,13 @@ def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
     return _readDictGroup(group, str, None)
 
 
-def _readVersionableGroup(group: h5py.Group) -> dict[str, Any]:
-    """Read a nested Versionable subgroup as a dict with metadata."""
+def _readVersionableGroup(group: h5py.Group, declaredType: Any = None) -> dict[str, Any]:
+    """Read a nested Versionable subgroup as a dict with metadata.
+
+    If *declaredType* is a Versionable subclass (e.g., from the parent's field
+    annotation), use it directly to resolve field types. Otherwise fall back to
+    looking up the class by the ``__OBJECT__`` name from file metadata.
+    """
     metaGroup = group[_VERSIONABLE_GROUP]
     objectName = str(metaGroup.attrs.get("__OBJECT__", ""))
 
@@ -446,8 +451,12 @@ def _readVersionableGroup(group: h5py.Group) -> dict[str, Any]:
         "__HASH__": str(metaGroup.attrs.get("__HASH__", "")),
     }
 
-    # Resolve field types from the class for nested reading
-    cls = _resolveClass(objectName)
+    # Use declared type if available, otherwise resolve by name
+    cls: type | None = None
+    if isinstance(declaredType, type) and issubclass(declaredType, Versionable):
+        cls = declaredType
+    else:
+        cls = _resolveClass(objectName)
     nestedFieldTypes = _resolveFields(cls) if cls is not None else {}
     result.update(_readFields(group, nestedFieldTypes))
     return result
@@ -497,7 +506,7 @@ def _readChild(item: h5py.Dataset | h5py.Group, elemType: Any) -> Any:
         return _readDataset(item, elemType)
     if isinstance(item, h5py.Group):
         if _VERSIONABLE_GROUP in item:
-            return _readVersionableGroup(item)
+            return _readVersionableGroup(item, elemType)
         return _readGroup(item, elemType)
     return None
 
@@ -586,12 +595,15 @@ def _makeLazyCollection(path: Path, group: h5py.Group, fieldType: Any) -> Any:
     groupPath = group.name.lstrip("/")
 
     origin = typing.get_origin(fieldType)
+    args = typing.get_args(fieldType)
     if origin is list:
         keys = sorted(group.keys(), key=int)
         return LazyArrayList(path, groupPath, keys)
     if origin is dict:
-        keys = list(group.keys())
-        return LazyArrayDict(path, groupPath, keys)
+        keyType = args[0] if args else str
+        hdf5Keys = list(group.keys())
+        decodedKeys = [_strToKey(k, keyType) for k in hdf5Keys]
+        return LazyArrayDict(path, groupPath, decodedKeys, hdf5Keys=hdf5Keys)
     # Shouldn't get here — _isArrayCollectionField guards the call
     return _readGroup(group, fieldType)
 

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -180,10 +180,10 @@ def _writeFields(
 
     for name, value in fields.items():
         fieldType = fieldTypes.get(name)
-        _writeField(group, name, value, fieldType, datasetKwargs, comp)
+        _writeValue(group, name, value, fieldType, datasetKwargs, comp)
 
 
-def _writeField(
+def _writeValue(
     group: h5py.Group,
     name: str,
     value: Any,
@@ -191,7 +191,10 @@ def _writeField(
     datasetKwargs: dict[str, Any],
     comp: Hdf5Compression,
 ) -> None:
-    """Write a single field to the group."""
+    """Write a single value to the group using recursive type dispatch.
+
+    Scalars → attributes, arrays → datasets, collections → groups (recursive).
+    """
     # None → h5py.Empty
     if value is None:
         group.attrs[name] = h5py.Empty("f")
@@ -223,18 +226,19 @@ def _writeField(
         group.attrs[name] = conv.serialize(value)
         return
 
-    # Collections — need to inspect fieldType
+    # Collections — recurse based on fieldType
     origin = typing.get_origin(fieldType)
     args = typing.get_args(fieldType)
 
-    if isinstance(value, list) and origin is list and args:
+    if isinstance(value, (list, set, frozenset, tuple)) and origin in (list, set, frozenset, tuple) and args:
         elemType = args[0]
-        _writeList(group, name, value, elemType, datasetKwargs, comp)
+        items = sorted(value, key=repr) if isinstance(value, (set, frozenset)) else list(value)
+        _writeSequence(group, name, items, elemType, datasetKwargs, comp)
         return
 
     if isinstance(value, dict) and origin is dict and args:
-        _valType = args[1]
-        _writeDict(group, name, value, _valType, datasetKwargs, comp)
+        valType = args[1]
+        _writeDict(group, name, value, valType, datasetKwargs, comp)
         return
 
     # Fallback: try as attribute (will raise if h5py can't store it)
@@ -247,7 +251,12 @@ def _writeField(
         ) from e
 
 
-def _writeList(
+def _isScalarType(elemType: Any) -> bool:
+    """Check if an element type is a scalar (storable as a dataset element)."""
+    return elemType in (int, float, str, bool)
+
+
+def _writeSequence(
     group: h5py.Group,
     name: str,
     values: list[Any],
@@ -255,61 +264,50 @@ def _writeList(
     datasetKwargs: dict[str, Any],
     comp: Hdf5Compression,
 ) -> None:
-    """Write a list field to the group."""
-    # list[np.ndarray] → group of integer-keyed datasets
-    if elemType is np.ndarray or (typing.get_origin(elemType) is not None and _isNdarrayType(elemType)):
-        subgroup = group.create_group(name)
-        for i, arr in enumerate(values):
-            subgroup.create_dataset(str(i), data=arr, **datasetKwargs)
+    """Write a sequence (list/set/tuple/frozenset) to the group.
+
+    Scalar elements → 1-D dataset. Non-scalar elements → group with
+    integer keys, each value written recursively.
+    """
+    if _isScalarType(elemType):
+        # Scalar sequence → 1-D dataset
+        if len(values) == 0:
+            dtype = _dtypeForElementType(elemType)
+            group.create_dataset(name, shape=(0,), dtype=dtype)
+        elif elemType is str:
+            group.create_dataset(name, data=values, dtype=h5py.string_dtype())
+        else:
+            group.create_dataset(name, data=values)
         return
 
-    # list[Versionable] → group of integer-keyed subgroups
-    concreteElem = typing.get_origin(elemType) or elemType
-    if isinstance(concreteElem, type) and issubclass(concreteElem, Versionable):
-        subgroup = group.create_group(name)
-        for i, item in enumerate(values):
-            _writeVersionable(subgroup, str(i), item, comp)
-        return
-
-    # list[numeric] / list[str] / list[bool] → 1-D dataset
-    if len(values) == 0:
-        dtype = _dtypeForElementType(elemType)
-        group.create_dataset(name, shape=(0,), dtype=dtype)
-    elif isinstance(values[0], str):
-        dt = h5py.string_dtype()
-        group.create_dataset(name, data=values, dtype=dt)
-    else:
-        group.create_dataset(name, data=values)
+    # Non-scalar → group with integer keys, recurse
+    subgroup = group.create_group(name)
+    for i, item in enumerate(values):
+        _writeValue(subgroup, str(i), item, elemType, datasetKwargs, comp)
 
 
 def _writeDict(
     group: h5py.Group,
     name: str,
-    values: dict[str, Any],
+    values: dict[Any, Any],
     valType: Any,
     datasetKwargs: dict[str, Any],
     comp: Hdf5Compression,
 ) -> None:
-    """Write a dict field to the group."""
-    # dict[str, np.ndarray] → group of named datasets
-    if valType is np.ndarray or _isNdarrayType(valType):
-        subgroup = group.create_group(name)
-        for key, arr in values.items():
-            subgroup.create_dataset(key, data=arr, **datasetKwargs)
-        return
+    """Write a dict to the group. Keys are converted to strings; values are recursive."""
+    subgroup = group.create_group(name)
+    for key, val in values.items():
+        strKey = _keyToStr(key)
+        _writeValue(subgroup, strKey, val, valType, datasetKwargs, comp)
 
-    # dict[str, Versionable] → group of named subgroups
-    concreteVal = typing.get_origin(valType) or valType
-    if isinstance(concreteVal, type) and issubclass(concreteVal, Versionable):
-        subgroup = group.create_group(name)
-        for key, item in values.items():
-            _writeVersionable(subgroup, key, item, comp)
-        return
 
-    raise BackendError(
-        f"Cannot store field '{name}' of type dict[str, {valType}] in HDF5. "
-        f"Consider restructuring your data or using a dict-based backend (JSON/YAML)."
-    )
+def _keyToStr(key: Any) -> str:
+    """Convert a dict key to a string for use as an HDF5 group/dataset name."""
+    if isinstance(key, str):
+        return key
+    if isinstance(key, Enum):
+        return str(key.value)
+    return str(key)
 
 
 def _writeVersionable(
@@ -380,8 +378,8 @@ def _readDataset(dataset: h5py.Dataset, fieldType: Any) -> Any:
     """Read a dataset, returning ndarray or list based on field type."""
     data = dataset[()]
 
-    # If the field type is a list, convert to Python list
-    if _isListField(fieldType):
+    # If the field type is a sequence of scalars, convert to Python list
+    if _isScalarSequenceField(fieldType):
         result = data.tolist() if isinstance(data, np.ndarray) else list(data)
         # h5py returns bytes for string datasets — decode to str
         if result and isinstance(result[0], bytes):
@@ -392,25 +390,26 @@ def _readDataset(dataset: h5py.Dataset, fieldType: Any) -> Any:
 
 
 def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
-    """Read a group, dispatching based on whether it's a Versionable or collection."""
+    """Read a group using recursive type dispatch."""
     # Versionable group: has __versionable__ child
     if _VERSIONABLE_GROUP in group:
         return _readVersionableGroup(group)
 
-    # Collection group: list or dict, determined by field type
+    # Collection group: determined by field type
     origin = typing.get_origin(fieldType)
     args = typing.get_args(fieldType)
 
-    if origin is list and args:
+    if origin in (list, set, frozenset, tuple) and args:
         elemType = args[0]
-        return _readListGroup(group, elemType)
+        return _readSequenceGroup(group, elemType)
 
     if origin is dict and args:
+        keyType = args[0]
         valType = args[1]
-        return _readDictGroup(group, valType)
+        return _readDictGroup(group, keyType, valType)
 
-    # Fallback: try as dict of arrays
-    return _readDictGroup(group, None)
+    # Fallback: try as dict of arrays (unknown type)
+    return _readDictGroup(group, str, None)
 
 
 def _readVersionableGroup(group: h5py.Group) -> dict[str, Any]:
@@ -431,42 +430,76 @@ def _readVersionableGroup(group: h5py.Group) -> dict[str, Any]:
     return result
 
 
-def _readListGroup(group: h5py.Group, elemType: Any) -> list[Any]:
-    """Read a list from a group with integer-keyed children."""
-    keys = sorted(group.keys(), key=int)
+def _readSequenceGroup(group: h5py.Group, elemType: Any) -> list[Any]:
+    """Read a sequence from a group with integer-keyed children (recursive).
 
-    concreteElem = typing.get_origin(elemType) or elemType
-    isVersionableElem = isinstance(concreteElem, type) and issubclass(concreteElem, Versionable)
+    Children may be datasets, groups, or attributes (for scalar elements).
+    """
+    # Collect all keys from both children and attributes
+    childKeys = set(group.keys())
+    attrKeys = set(group.attrs.keys())
+    allKeys = sorted(childKeys | attrKeys, key=int)
 
     result: list[Any] = []
-    for key in keys:
-        item = group[key]
-        if isVersionableElem and isinstance(item, h5py.Group):
-            result.append(_readVersionableGroup(item))
-        elif isinstance(item, h5py.Dataset):
-            result.append(item[()])
-        elif isinstance(item, h5py.Group):
-            result.append(_readGroup(item, elemType))
+    for key in allKeys:
+        if key in childKeys:
+            result.append(_readChild(group[key], elemType))
+        else:
+            result.append(_readAttr(group.attrs[key]))
     return result
 
 
-def _readDictGroup(group: h5py.Group, valType: Any) -> dict[str, Any]:
-    """Read a dict from a group with named children."""
-    concreteVal = typing.get_origin(valType) or valType if valType is not None else None
-    isVersionableVal = isinstance(concreteVal, type) and issubclass(concreteVal, Versionable)
+def _readDictGroup(group: h5py.Group, keyType: Any, valType: Any) -> dict[Any, Any]:
+    """Read a dict from a group (recursive). Keys are converted from strings."""
+    result: dict[Any, Any] = {}
 
-    result: dict[str, Any] = {}
-    for key in group:
-        if key == _VERSIONABLE_GROUP:
+    # Read child items (datasets and groups)
+    for strKey in group:
+        if strKey == _VERSIONABLE_GROUP:
             continue
-        item = group[key]
-        if isVersionableVal and isinstance(item, h5py.Group):
-            result[key] = _readVersionableGroup(item)
-        elif isinstance(item, h5py.Dataset):
-            result[key] = item[()]
-        elif isinstance(item, h5py.Group):
-            result[key] = _readGroup(item, valType)
+        key = _strToKey(strKey, keyType)
+        result[key] = _readChild(group[strKey], valType)
+
+    # Read attributes (scalar dict values are stored as attrs on the subgroup)
+    for strKey in group.attrs:
+        key = _strToKey(strKey, keyType)
+        result[key] = _readAttr(group.attrs[strKey])
+
     return result
+
+
+def _readChild(item: h5py.Dataset | h5py.Group, elemType: Any) -> Any:
+    """Read a single child item (dataset or group) with recursive dispatch."""
+    if isinstance(item, h5py.Dataset):
+        return _readDataset(item, elemType)
+    if isinstance(item, h5py.Group):
+        if _VERSIONABLE_GROUP in item:
+            return _readVersionableGroup(item)
+        return _readGroup(item, elemType)
+    return None
+
+
+def _strToKey(strKey: str, keyType: Any) -> Any:
+    """Convert a string HDF5 key back to the original dict key type."""
+    if keyType is str or keyType is None:
+        return strKey
+    if keyType is int:
+        return int(strKey)
+    if keyType is float:
+        return float(strKey)
+    if keyType is bool:
+        return strKey == "True"
+    if isinstance(keyType, type) and issubclass(keyType, Enum):
+        # Try to match by value
+        for member in keyType:
+            if str(member.value) == strKey:
+                return member
+        return strKey
+    # Try converter registry
+    conv = _registry.get(keyType)
+    if conv is not None:
+        return conv.deserialize(strKey, keyType)
+    return strKey
 
 
 def _readAttr(value: Any) -> Any:
@@ -560,12 +593,15 @@ def _isNdarrayType(fieldType: Any) -> bool:
     return False
 
 
-def _isListField(fieldType: Any) -> bool:
-    """Check if a field type is a list type."""
+def _isScalarSequenceField(fieldType: Any) -> bool:
+    """Check if a field type is a sequence of scalars (stored as a 1-D dataset)."""
     if fieldType is None:
         return False
     origin = typing.get_origin(fieldType)
-    return origin is list
+    if origin not in (list, set, frozenset, tuple):
+        return False
+    args = typing.get_args(fieldType)
+    return bool(args) and _isScalarType(args[0])
 
 
 def _dtypeForElementType(elemType: Any) -> np.dtype[Any] | Any:

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -116,7 +116,12 @@ class Hdf5Backend(Backend):
                 meta = _readMeta(f)
                 if cls is None:
                     cls = _resolveClass(meta["__OBJECT__"])
-                fieldTypes = _resolveFields(cls) if cls is not None else {}
+                if cls is None:
+                    raise BackendError(
+                        f"Unknown Versionable type {meta['__OBJECT__']!r} in {path}. "
+                        f"Ensure the class is imported and registered."
+                    )
+                fieldTypes = _resolveFields(cls)
 
                 fields, lazyFields = _readFields(f, fieldTypes, ctx)
 

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -20,7 +20,9 @@ import h5py
 import numpy as np
 
 from versionable._backend import Backend, registerBackend
+from versionable._base import _resolveFields
 from versionable._hdf5_compression import ZSTD_DEFAULT, Hdf5Compression
+from versionable._types import serialize
 from versionable.errors import BackendError
 
 logger = logging.getLogger(__name__)
@@ -37,9 +39,13 @@ class Hdf5Backend(Backend):
         meta: dict[str, Any],
         path: Path,
         *,
+        cls: type,
         compression: Hdf5Compression | None = None,
         **kwargs: Any,
     ) -> None:
+        fieldTypes = _resolveFields(cls)
+        fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
+
         comp = compression or ZSTD_DEFAULT
         try:
             with h5py.File(path, "w") as f:

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -1,18 +1,30 @@
-"""HDF5 storage backend.
+"""HDF5 storage backend with native type mapping.
 
-Stores Versionable objects in HDF5 files with:
-- Metadata as root-level attributes
-- Scalar/collection fields as JSON-encoded attributes on a ``fields`` group
-- Array fields as HDF5 datasets with dtype/shape preserved
-- Nested Versionable objects as subgroups (recursive)
+Every field maps to a native HDF5 construct — no JSON anywhere:
+
+- Scalar primitives (int, float, bool, str) → HDF5 attributes
+- ``np.ndarray`` → HDF5 datasets (with compression)
+- ``list[numeric]`` / ``list[str]`` / ``list[bool]`` → 1-D datasets
+- ``list[np.ndarray]`` → group of integer-keyed datasets
+- ``dict[str, np.ndarray]`` → group of named datasets
+- Nested ``Versionable`` → subgroup with ``__versionable__`` metadata group
+- ``list[Versionable]`` → group of integer-keyed subgroups
+- ``None`` → ``h5py.Empty("f")`` attribute
+- Enum → attribute (stores ``.value``)
+- Converted types (datetime, Path, etc.) → attribute (converter output)
+
+Metadata (``__OBJECT__``, ``__VERSION__``, ``__HASH__``) is stored in a
+``__versionable__`` child group, distinguishing Versionable groups from
+plain collection groups.
 
 Supports lazy loading of array fields via ``LazyArray`` sentinels.
 """
 
 from __future__ import annotations
 
-import json
 import logging
+import typing
+from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -20,12 +32,14 @@ import h5py
 import numpy as np
 
 from versionable._backend import Backend, registerBackend
-from versionable._base import _resolveFields
+from versionable._base import Versionable, _resolveFields, metadata
 from versionable._hdf5_compression import ZSTD_DEFAULT, Hdf5Compression
-from versionable._types import serialize
+from versionable._types import _registry
 from versionable.errors import BackendError
 
 logger = logging.getLogger(__name__)
+
+_VERSIONABLE_GROUP = "__versionable__"
 
 
 class Hdf5Backend(Backend):
@@ -43,31 +57,29 @@ class Hdf5Backend(Backend):
         compression: Hdf5Compression | None = None,
         **kwargs: Any,
     ) -> None:
-        fieldTypes = _resolveFields(cls)
-        fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
-
         comp = compression or ZSTD_DEFAULT
+        fieldTypes = _resolveFields(cls)
         try:
             with h5py.File(path, "w") as f:
-                # Write metadata as root attributes
-                f.attrs["__OBJECT__"] = meta["name"]
-                f.attrs["__VERSION__"] = meta["version"]
-                f.attrs["__HASH__"] = meta["hash"]
+                # Write metadata into __versionable__ child group
+                metaGroup = f.create_group(_VERSIONABLE_GROUP)
+                metaGroup.attrs["__OBJECT__"] = meta["name"]
+                metaGroup.attrs["__VERSION__"] = meta["version"]
+                metaGroup.attrs["__HASH__"] = meta["hash"]
 
                 # Write fields
-                _writeGroup(f, fields, comp)
+                _writeFields(f, fields, fieldTypes, comp)
         except OSError as e:
             raise BackendError(f"Failed to write HDF5 to {path}: {e}") from e
 
     def load(self, path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
         try:
             with h5py.File(path, "r") as f:
-                meta = {
-                    "__OBJECT__": str(f.attrs.get("__OBJECT__", "")),
-                    "__VERSION__": int(f.attrs.get("__VERSION__", 1)),
-                    "__HASH__": str(f.attrs.get("__HASH__", "")),
-                }
-                fields = _readGroup(f)
+                meta = _readMeta(f)
+                objectName = meta["__OBJECT__"]
+                cls = _resolveClass(objectName)
+                fieldTypes = _resolveFields(cls) if cls is not None else {}
+                fields = _readFields(f, fieldTypes)
             return fields, meta
         except OSError as e:
             raise BackendError(f"Failed to read HDF5 from {path}: {e}") from e
@@ -76,6 +88,7 @@ class Hdf5Backend(Backend):
         self,
         path: Path,
         *,
+        cls: type | None = None,
         preload: list[str] | str | None = None,
         metadataOnly: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any], set[str]]:
@@ -93,38 +106,43 @@ class Hdf5Backend(Backend):
 
         try:
             with h5py.File(path, "r") as f:
-                meta = {
-                    "__OBJECT__": str(f.attrs.get("__OBJECT__", "")),
-                    "__VERSION__": int(f.attrs.get("__VERSION__", 1)),
-                    "__HASH__": str(f.attrs.get("__HASH__", "")),
-                }
+                meta = _readMeta(f)
+                if cls is None:
+                    cls = _resolveClass(meta["__OBJECT__"])
+                fieldTypes = _resolveFields(cls) if cls is not None else {}
 
                 fields: dict[str, Any] = {}
                 lazyFields: set[str] = set()
 
                 for key in f:
-                    item = f[key]
-                    if isinstance(item, h5py.Dataset):
-                        if metadataOnly:
-                            fields[key] = ArrayNotLoaded(key)
-                            lazyFields.add(key)
-                        elif preloadAll or key in preloadSet:
-                            fields[key] = item[()]
-                        else:
-                            fields[key] = LazyArray(path, key)
-                            lazyFields.add(key)
-                    elif isinstance(item, h5py.Group):
-                        # Check if it's a nested Versionable (has __OBJECT__ attr)
-                        if "__OBJECT__" in item.attrs:
-                            fields[key] = _readNestedGroup(item)
-                        else:
-                            # Regular group: read as dict
-                            fields[key] = _readGroup(item)
+                    if key == _VERSIONABLE_GROUP:
+                        continue
 
-                # Read JSON-encoded scalar attributes
-                if "__scalars__" in f.attrs:
-                    scalars = json.loads(f.attrs["__scalars__"])
-                    fields.update(scalars)
+                    item = f[key]
+                    fieldType = fieldTypes.get(key)
+
+                    if isinstance(item, h5py.Dataset):
+                        if _isArrayField(fieldType):
+                            # np.ndarray field — lazy loading applies
+                            if metadataOnly:
+                                fields[key] = ArrayNotLoaded(key)
+                                lazyFields.add(key)
+                            elif preloadAll or key in preloadSet:
+                                fields[key] = item[()]
+                            else:
+                                fields[key] = LazyArray(path, key)
+                                lazyFields.add(key)
+                        else:
+                            # list[numeric], list[str], etc. — always eager
+                            fields[key] = _readDataset(item, fieldType)
+                    elif isinstance(item, h5py.Group):
+                        fields[key] = _readGroup(item, fieldType)
+
+                # Read scalar attributes
+                for attrName in f.attrs:
+                    if attrName == _VERSIONABLE_GROUP:
+                        continue
+                    fields[attrName] = _readAttr(f.attrs[attrName])
 
             return fields, meta, lazyFields
         except OSError as e:
@@ -136,37 +154,170 @@ class Hdf5Backend(Backend):
 # ---------------------------------------------------------------------------
 
 
-def _writeGroup(group: h5py.Group, fields: dict[str, Any], comp: Hdf5Compression) -> None:
-    """Write fields into an HDF5 group.
-
-    Arrays → datasets, nested dicts with __OBJECT__ → subgroups,
-    everything else → JSON-encoded in the __scalars__ attribute.
-    """
-    scalars: dict[str, Any] = {}
+def _writeFields(
+    group: h5py.Group,
+    fields: dict[str, Any],
+    fieldTypes: dict[str, Any],
+    comp: Hdf5Compression,
+) -> None:
+    """Write fields into an HDF5 group using native type dispatch."""
     datasetKwargs = comp.datasetKwargs()
 
-    for key, value in fields.items():
-        if isinstance(value, np.ndarray):
-            group.create_dataset(key, data=value, **datasetKwargs)
-        elif isinstance(value, dict) and "__OBJECT__" in value:
-            _writeNestedGroup(group, key, value, comp)
-        else:
-            scalars[key] = value
-
-    if scalars:
-        group.attrs["__scalars__"] = json.dumps(scalars, default=str)
+    for name, value in fields.items():
+        fieldType = fieldTypes.get(name)
+        _writeField(group, name, value, fieldType, datasetKwargs, comp)
 
 
-def _writeNestedGroup(parent: h5py.Group, name: str, data: dict[str, Any], comp: Hdf5Compression) -> None:
-    """Write a nested Versionable as a subgroup."""
+def _writeField(  # noqa: PLR0911 — type dispatch; many returns are inherent
+    group: h5py.Group,
+    name: str,
+    value: Any,
+    fieldType: Any,
+    datasetKwargs: dict[str, Any],
+    comp: Hdf5Compression,
+) -> None:
+    """Write a single field to the group."""
+    # None → h5py.Empty
+    if value is None:
+        group.attrs[name] = h5py.Empty("f")
+        return
+
+    # np.ndarray → dataset with compression
+    if isinstance(value, np.ndarray):
+        group.create_dataset(name, data=value, **datasetKwargs)
+        return
+
+    # Nested Versionable → subgroup with __versionable__
+    if isinstance(value, Versionable):
+        _writeVersionable(group, name, value, comp)
+        return
+
+    # Enum → store .value as attribute
+    if isinstance(value, Enum):
+        group.attrs[name] = value.value
+        return
+
+    # Scalar primitives → attribute
+    if isinstance(value, (int, float, str, bool)):
+        group.attrs[name] = value
+        return
+
+    # Converted types (datetime, Path, etc.) → apply converter, write attribute
+    conv = _registry.get(type(value))
+    if conv is not None:
+        group.attrs[name] = conv.serialize(value)
+        return
+
+    # Collections — need to inspect fieldType
+    origin = typing.get_origin(fieldType)
+    args = typing.get_args(fieldType)
+
+    if isinstance(value, list) and origin is list and args:
+        elemType = args[0]
+        _writeList(group, name, value, elemType, datasetKwargs, comp)
+        return
+
+    if isinstance(value, dict) and origin is dict and args:
+        _valType = args[1]
+        _writeDict(group, name, value, _valType, datasetKwargs, comp)
+        return
+
+    # Fallback: try as attribute (will raise if h5py can't store it)
+    try:
+        group.attrs[name] = value
+    except TypeError as e:
+        raise BackendError(
+            f"Cannot store field '{name}' of type {type(value).__name__} in HDF5. "
+            f"Consider restructuring your data or using a dict-based backend (JSON/YAML)."
+        ) from e
+
+
+def _writeList(
+    group: h5py.Group,
+    name: str,
+    values: list[Any],
+    elemType: Any,
+    datasetKwargs: dict[str, Any],
+    comp: Hdf5Compression,
+) -> None:
+    """Write a list field to the group."""
+    # list[np.ndarray] → group of integer-keyed datasets
+    if elemType is np.ndarray or (typing.get_origin(elemType) is not None and _isNdarrayType(elemType)):
+        subgroup = group.create_group(name)
+        for i, arr in enumerate(values):
+            subgroup.create_dataset(str(i), data=arr, **datasetKwargs)
+        return
+
+    # list[Versionable] → group of integer-keyed subgroups
+    concreteElem = typing.get_origin(elemType) or elemType
+    if isinstance(concreteElem, type) and issubclass(concreteElem, Versionable):
+        subgroup = group.create_group(name)
+        for i, item in enumerate(values):
+            _writeVersionable(subgroup, str(i), item, comp)
+        return
+
+    # list[numeric] / list[str] / list[bool] → 1-D dataset
+    if len(values) == 0:
+        dtype = _dtypeForElementType(elemType)
+        group.create_dataset(name, shape=(0,), dtype=dtype)
+    elif isinstance(values[0], str):
+        dt = h5py.string_dtype()
+        group.create_dataset(name, data=values, dtype=dt)
+    else:
+        group.create_dataset(name, data=values)
+
+
+def _writeDict(
+    group: h5py.Group,
+    name: str,
+    values: dict[str, Any],
+    valType: Any,
+    datasetKwargs: dict[str, Any],
+    comp: Hdf5Compression,
+) -> None:
+    """Write a dict field to the group."""
+    # dict[str, np.ndarray] → group of named datasets
+    if valType is np.ndarray or _isNdarrayType(valType):
+        subgroup = group.create_group(name)
+        for key, arr in values.items():
+            subgroup.create_dataset(key, data=arr, **datasetKwargs)
+        return
+
+    # dict[str, Versionable] → group of named subgroups
+    concreteVal = typing.get_origin(valType) or valType
+    if isinstance(concreteVal, type) and issubclass(concreteVal, Versionable):
+        subgroup = group.create_group(name)
+        for key, item in values.items():
+            _writeVersionable(subgroup, key, item, comp)
+        return
+
+    raise BackendError(
+        f"Cannot store field '{name}' of type dict[str, {valType}] in HDF5. "
+        f"Consider restructuring your data or using a dict-based backend (JSON/YAML)."
+    )
+
+
+def _writeVersionable(
+    parent: h5py.Group,
+    name: str,
+    obj: Versionable,
+    comp: Hdf5Compression,
+) -> None:
+    """Write a nested Versionable as a subgroup with __versionable__ metadata."""
     subgroup = parent.create_group(name)
-    subgroup.attrs["__OBJECT__"] = data.get("__OBJECT__", "")
-    subgroup.attrs["__VERSION__"] = data.get("__VERSION__", 1)
-    subgroup.attrs["__HASH__"] = data.get("__HASH__", "")
+    objType = type(obj)
+    meta = metadata(objType)
+    fieldTypes = _resolveFields(objType)
 
-    # Write the remaining fields (exclude metadata keys)
-    nested = {k: v for k, v in data.items() if not k.startswith("__")}
-    _writeGroup(subgroup, nested, comp)
+    # Write metadata into __versionable__ child group
+    metaGroup = subgroup.create_group(_VERSIONABLE_GROUP)
+    metaGroup.attrs["__OBJECT__"] = meta.name
+    metaGroup.attrs["__VERSION__"] = meta.version
+    metaGroup.attrs["__HASH__"] = meta.hash
+
+    # Recursively write fields
+    fields = {fieldName: getattr(obj, fieldName) for fieldName in fieldTypes}
+    _writeFields(subgroup, fields, fieldTypes, comp)
 
 
 # ---------------------------------------------------------------------------
@@ -174,37 +325,214 @@ def _writeNestedGroup(parent: h5py.Group, name: str, data: dict[str, Any], comp:
 # ---------------------------------------------------------------------------
 
 
-def _readGroup(group: h5py.Group) -> dict[str, Any]:
+def _readMeta(group: h5py.Group) -> dict[str, Any]:
+    """Read metadata from the __versionable__ child group."""
+    if _VERSIONABLE_GROUP in group:
+        metaGroup = group[_VERSIONABLE_GROUP]
+        return {
+            "__OBJECT__": str(metaGroup.attrs.get("__OBJECT__", "")),
+            "__VERSION__": int(metaGroup.attrs.get("__VERSION__", 1)),
+            "__HASH__": str(metaGroup.attrs.get("__HASH__", "")),
+        }
+    # Should not happen for well-formed files
+    return {"__OBJECT__": "", "__VERSION__": 1, "__HASH__": ""}
+
+
+def _readFields(group: h5py.Group, fieldTypes: dict[str, Any]) -> dict[str, Any]:
     """Read all fields from an HDF5 group (eager)."""
     fields: dict[str, Any] = {}
 
+    # Read child items (datasets and groups)
     for key in group:
+        if key == _VERSIONABLE_GROUP:
+            continue
         item = group[key]
+        fieldType = fieldTypes.get(key)
+
         if isinstance(item, h5py.Dataset):
-            fields[key] = item[()]
+            fields[key] = _readDataset(item, fieldType)
         elif isinstance(item, h5py.Group):
-            if "__OBJECT__" in item.attrs:
-                fields[key] = _readNestedGroup(item)
-            else:
-                fields[key] = _readGroup(item)
+            fields[key] = _readGroup(item, fieldType)
 
     # Read scalar attributes
-    if "__scalars__" in group.attrs:
-        scalars = json.loads(group.attrs["__scalars__"])
-        fields.update(scalars)
+    for attrName in group.attrs:
+        fields[attrName] = _readAttr(group.attrs[attrName])
 
     return fields
 
 
-def _readNestedGroup(group: h5py.Group) -> dict[str, Any]:
+def _readDataset(dataset: h5py.Dataset, fieldType: Any) -> Any:
+    """Read a dataset, returning ndarray or list based on field type."""
+    data = dataset[()]
+
+    # If the field type is a list, convert to Python list
+    if _isListField(fieldType):
+        result = data.tolist() if isinstance(data, np.ndarray) else list(data)
+        # h5py returns bytes for string datasets — decode to str
+        if result and isinstance(result[0], bytes):
+            return [v.decode("utf-8") for v in result]
+        return result
+
+    return data
+
+
+def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
+    """Read a group, dispatching based on whether it's a Versionable or collection."""
+    # Versionable group: has __versionable__ child
+    if _VERSIONABLE_GROUP in group:
+        return _readVersionableGroup(group)
+
+    # Collection group: list or dict, determined by field type
+    origin = typing.get_origin(fieldType)
+    args = typing.get_args(fieldType)
+
+    if origin is list and args:
+        elemType = args[0]
+        return _readListGroup(group, elemType)
+
+    if origin is dict and args:
+        valType = args[1]
+        return _readDictGroup(group, valType)
+
+    # Fallback: try as dict of arrays
+    return _readDictGroup(group, None)
+
+
+def _readVersionableGroup(group: h5py.Group) -> dict[str, Any]:
     """Read a nested Versionable subgroup as a dict with metadata."""
+    metaGroup = group[_VERSIONABLE_GROUP]
+    objectName = str(metaGroup.attrs.get("__OBJECT__", ""))
+
     result: dict[str, Any] = {
-        "__OBJECT__": str(group.attrs.get("__OBJECT__", "")),
-        "__VERSION__": int(group.attrs.get("__VERSION__", 1)),
-        "__HASH__": str(group.attrs.get("__HASH__", "")),
+        "__OBJECT__": objectName,
+        "__VERSION__": int(metaGroup.attrs.get("__VERSION__", 1)),
+        "__HASH__": str(metaGroup.attrs.get("__HASH__", "")),
     }
-    result.update(_readGroup(group))
+
+    # Resolve field types from the class for nested reading
+    cls = _resolveClass(objectName)
+    nestedFieldTypes = _resolveFields(cls) if cls is not None else {}
+    result.update(_readFields(group, nestedFieldTypes))
     return result
+
+
+def _readListGroup(group: h5py.Group, elemType: Any) -> list[Any]:
+    """Read a list from a group with integer-keyed children."""
+    keys = sorted(group.keys(), key=int)
+
+    concreteElem = typing.get_origin(elemType) or elemType
+    isVersionableElem = isinstance(concreteElem, type) and issubclass(concreteElem, Versionable)
+
+    result: list[Any] = []
+    for key in keys:
+        item = group[key]
+        if isVersionableElem and isinstance(item, h5py.Group):
+            result.append(_readVersionableGroup(item))
+        elif isinstance(item, h5py.Dataset):
+            result.append(item[()])
+        elif isinstance(item, h5py.Group):
+            result.append(_readGroup(item, elemType))
+    return result
+
+
+def _readDictGroup(group: h5py.Group, valType: Any) -> dict[str, Any]:
+    """Read a dict from a group with named children."""
+    concreteVal = typing.get_origin(valType) or valType if valType is not None else None
+    isVersionableVal = isinstance(concreteVal, type) and issubclass(concreteVal, Versionable)
+
+    result: dict[str, Any] = {}
+    for key in group:
+        if key == _VERSIONABLE_GROUP:
+            continue
+        item = group[key]
+        if isVersionableVal and isinstance(item, h5py.Group):
+            result[key] = _readVersionableGroup(item)
+        elif isinstance(item, h5py.Dataset):
+            result[key] = item[()]
+        elif isinstance(item, h5py.Group):
+            result[key] = _readGroup(item, valType)
+    return result
+
+
+def _readAttr(value: Any) -> Any:  # noqa: PLR0911 — type dispatch
+    """Convert an HDF5 attribute value to a Python value."""
+    # h5py.Empty → None
+    if isinstance(value, h5py.Empty):
+        return None
+
+    # numpy scalars → Python primitives
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.bytes_):
+        return value.decode("utf-8")
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Type inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolveClass(objectName: str) -> type | None:
+    """Look up a Versionable class by its serialization name."""
+    from versionable._base import registeredClasses
+
+    registry = registeredClasses()
+    return registry.get(objectName)
+
+
+def _isArrayField(fieldType: Any) -> bool:
+    """Check if a field type is np.ndarray (not a list stored as dataset)."""
+    if fieldType is None:
+        return True  # unknown type, assume array (backward compat)
+    origin = typing.get_origin(fieldType)
+    if origin is not None:
+        # e.g. npt.NDArray[np.float64] has origin np.ndarray
+        return _isNdarrayType(fieldType)
+    return fieldType is np.ndarray
+
+
+def _isNdarrayType(fieldType: Any) -> bool:
+    """Check if a type annotation refers to np.ndarray."""
+    origin = typing.get_origin(fieldType)
+    if origin is np.ndarray:
+        return True
+    if fieldType is np.ndarray:
+        return True
+    # Check for npt.NDArray which is Annotated[ndarray, ...]
+    if origin is not None:
+        args = typing.get_args(fieldType)
+        if args and args[0] is np.ndarray:
+            return True
+    return False
+
+
+def _isListField(fieldType: Any) -> bool:
+    """Check if a field type is a list type."""
+    if fieldType is None:
+        return False
+    origin = typing.get_origin(fieldType)
+    return origin is list
+
+
+def _dtypeForElementType(elemType: Any) -> np.dtype[Any] | Any:
+    """Map a Python element type to a numpy dtype for empty datasets."""
+    if elemType is int:
+        return np.dtype(np.int64)
+    if elemType is float:
+        return np.dtype(np.float64)
+    if elemType is bool:
+        return np.dtype(np.bool_)
+    if elemType is str:
+        return h5py.string_dtype()
+    return np.dtype(np.float64)  # fallback
 
 
 # Register for .h5 and .hdf5 extensions

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -35,6 +35,7 @@ import numpy as np
 from versionable._backend import Backend, registerBackend
 from versionable._base import Versionable, _resolveFields, metadata
 from versionable._hdf5_compression import ZSTD_DEFAULT, Hdf5Compression
+from versionable._lazy import ArrayNotLoaded, LazyArray, LazyContext
 from versionable._types import _registry
 from versionable.errors import BackendError
 
@@ -85,7 +86,7 @@ class Hdf5Backend(Backend):
                         f"Ensure the class is imported and registered."
                     )
                 fieldTypes = _resolveFields(cls)
-                fields = _readFields(f, fieldTypes)
+                fields, _ = _readFields(f, fieldTypes)
             return fields, meta
         except OSError as e:
             raise BackendError(f"Failed to read HDF5 from {path}: {e}") from e
@@ -103,12 +104,12 @@ class Hdf5Backend(Backend):
         Returns:
             Tuple of (fields_dict, metadata_dict, lazy_field_names).
             Array fields not in *preload* are returned as ``LazyArray``
-            sentinels.
+            sentinels.  Lazy loading is recursive — arrays inside nested
+            Versionable objects also get lazy sentinels.
         """
-        from versionable._lazy import ArrayNotLoaded, LazyArray
-
         preloadAll = preload == "*"
         preloadSet = set(preload) if isinstance(preload, list) else set()
+        ctx = LazyContext(path=path, preloadAll=preloadAll, preloadSet=preloadSet, metadataOnly=metadataOnly)
 
         try:
             with h5py.File(path, "r") as f:
@@ -117,53 +118,7 @@ class Hdf5Backend(Backend):
                     cls = _resolveClass(meta["__OBJECT__"])
                 fieldTypes = _resolveFields(cls) if cls is not None else {}
 
-                fields: dict[str, Any] = {}
-                lazyFields: set[str] = set()
-
-                for key in f:
-                    if key == _VERSIONABLE_GROUP:
-                        continue
-
-                    item = f[key]
-                    fieldType = fieldTypes.get(key)
-
-                    if isinstance(item, h5py.Dataset):
-                        if _isArrayField(fieldType):
-                            # np.ndarray field — lazy loading applies
-                            if metadataOnly:
-                                fields[key] = ArrayNotLoaded(key)
-                                lazyFields.add(key)
-                            elif preloadAll or key in preloadSet:
-                                fields[key] = item[()]
-                            else:
-                                fields[key] = LazyArray(path, key)
-                                lazyFields.add(key)
-                        else:
-                            # list[numeric], list[str], etc. — always eager
-                            fields[key] = _readDataset(item, fieldType)
-                    elif isinstance(item, h5py.Group):
-                        if _VERSIONABLE_GROUP in item:
-                            # Nested Versionable — always eager
-                            fields[key] = _readGroup(item, fieldType)
-                        elif _isArrayCollectionField(fieldType):
-                            # list[ndarray] or dict[str, ndarray] — lazy per-element
-                            if metadataOnly:
-                                fields[key] = ArrayNotLoaded(key)
-                                lazyFields.add(key)
-                            elif preloadAll or key in preloadSet:
-                                fields[key] = _readGroup(item, fieldType)
-                            else:
-                                fields[key] = _makeLazyCollection(path, item, fieldType)
-                                lazyFields.add(key)
-                        else:
-                            # Other groups (list[Versionable], etc.) — eager
-                            fields[key] = _readGroup(item, fieldType)
-
-                # Read scalar attributes
-                for attrName in f.attrs:
-                    if attrName == _VERSIONABLE_GROUP:
-                        continue
-                    fields[attrName] = _readAttr(f.attrs[attrName])
+                fields, lazyFields = _readFields(f, fieldTypes, ctx)
 
             return fields, meta, lazyFields
         except OSError as e:
@@ -374,9 +329,19 @@ def _readMeta(group: h5py.Group) -> dict[str, Any]:
     return {"__OBJECT__": "", "__VERSION__": 1, "__HASH__": ""}
 
 
-def _readFields(group: h5py.Group, fieldTypes: dict[str, Any]) -> dict[str, Any]:
-    """Read all fields from an HDF5 group (eager)."""
+def _readFields(
+    group: h5py.Group,
+    fieldTypes: dict[str, Any],
+    ctx: LazyContext | None = None,
+) -> tuple[dict[str, Any], set[str]]:
+    """Read all fields from an HDF5 group.
+
+    Returns:
+        Tuple of (fields_dict, lazy_field_names).  When *ctx* is ``None``
+        all fields are eager and the lazy set is empty.
+    """
     fields: dict[str, Any] = {}
+    lazyFields: set[str] = set()
 
     # Read child items (datasets and groups)
     for key in group:
@@ -386,15 +351,41 @@ def _readFields(group: h5py.Group, fieldTypes: dict[str, Any]) -> dict[str, Any]
         fieldType = fieldTypes.get(key)
 
         if isinstance(item, h5py.Dataset):
-            fields[key] = _readDataset(item, fieldType)
+            if ctx is not None and _isArrayField(fieldType):
+                # np.ndarray field — lazy loading applies
+                datasetPath = item.name.lstrip("/")
+                if ctx.metadataOnly:
+                    fields[key] = ArrayNotLoaded(key)
+                    lazyFields.add(key)
+                elif ctx.preloadAll or key in ctx.preloadSet:
+                    fields[key] = item[()]
+                else:
+                    fields[key] = LazyArray(ctx.path, datasetPath)
+                    lazyFields.add(key)
+            else:
+                fields[key] = _readDataset(item, fieldType)
         elif isinstance(item, h5py.Group):
-            fields[key] = _readGroup(item, fieldType)
+            if _VERSIONABLE_GROUP in item:
+                # Nested Versionable — recurse with lazy context
+                fields[key] = _readVersionableGroup(item, fieldType, ctx)
+            elif ctx is not None and _isArrayCollectionField(fieldType):
+                # list[ndarray] or dict[str, ndarray] — lazy per-element
+                if ctx.metadataOnly:
+                    fields[key] = ArrayNotLoaded(key)
+                    lazyFields.add(key)
+                elif ctx.preloadAll or key in ctx.preloadSet:
+                    fields[key] = _readGroup(item, fieldType)
+                else:
+                    fields[key] = _makeLazyCollection(ctx.path, item, fieldType)
+                    lazyFields.add(key)
+            else:
+                fields[key] = _readGroup(item, fieldType, ctx)
 
-    # Read scalar attributes
+    # Read scalar attributes (always eager)
     for attrName in group.attrs:
         fields[attrName] = _readAttr(group.attrs[attrName])
 
-    return fields
+    return fields, lazyFields
 
 
 def _readDataset(dataset: h5py.Dataset, fieldType: Any) -> Any:
@@ -412,11 +403,11 @@ def _readDataset(dataset: h5py.Dataset, fieldType: Any) -> Any:
     return data
 
 
-def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
+def _readGroup(group: h5py.Group, fieldType: Any, ctx: LazyContext | None = None) -> Any:
     """Read a group using recursive type dispatch."""
     # Versionable group: has __versionable__ child
     if _VERSIONABLE_GROUP in group:
-        return _readVersionableGroup(group, fieldType)
+        return _readVersionableGroup(group, fieldType, ctx)
 
     # Collection group: determined by field type
     origin = typing.get_origin(fieldType)
@@ -424,23 +415,29 @@ def _readGroup(group: h5py.Group, fieldType: Any) -> Any:
 
     if origin in (list, set, frozenset, tuple) and args:
         elemType = args[0]
-        return _readSequenceGroup(group, elemType)
+        return _readSequenceGroup(group, elemType, ctx)
 
     if origin is dict and args:
         keyType = args[0]
         valType = args[1]
-        return _readDictGroup(group, keyType, valType)
+        return _readDictGroup(group, keyType, valType, ctx)
 
     # Fallback: try as dict of arrays (unknown type)
-    return _readDictGroup(group, str, None)
+    return _readDictGroup(group, str, None, ctx)
 
 
-def _readVersionableGroup(group: h5py.Group, declaredType: Any = None) -> dict[str, Any]:
+def _readVersionableGroup(
+    group: h5py.Group, declaredType: Any = None, ctx: LazyContext | None = None
+) -> dict[str, Any]:
     """Read a nested Versionable subgroup as a dict with metadata.
 
     If *declaredType* is a Versionable subclass (e.g., from the parent's field
     annotation), use it directly to resolve field types. Otherwise fall back to
     looking up the class by the ``__OBJECT__`` name from file metadata.
+
+    When *ctx* is provided, array fields inside the nested object get lazy
+    sentinels. The set of lazy field names is stored under ``__lazy__`` so
+    ``_deserializeVersionable`` can apply ``makeLazyInstance``.
     """
     metaGroup = group[_VERSIONABLE_GROUP]
     objectName = str(metaGroup.attrs.get("__OBJECT__", ""))
@@ -458,11 +455,14 @@ def _readVersionableGroup(group: h5py.Group, declaredType: Any = None) -> dict[s
     else:
         cls = _resolveClass(objectName)
     nestedFieldTypes = _resolveFields(cls) if cls is not None else {}
-    result.update(_readFields(group, nestedFieldTypes))
+    nestedFields, lazyFields = _readFields(group, nestedFieldTypes, ctx)
+    result.update(nestedFields)
+    if lazyFields:
+        result["__lazy__"] = lazyFields
     return result
 
 
-def _readSequenceGroup(group: h5py.Group, elemType: Any) -> list[Any]:
+def _readSequenceGroup(group: h5py.Group, elemType: Any, ctx: LazyContext | None = None) -> list[Any]:
     """Read a sequence from a group with integer-keyed children (recursive).
 
     Children may be datasets, groups, or attributes (for scalar elements).
@@ -475,13 +475,13 @@ def _readSequenceGroup(group: h5py.Group, elemType: Any) -> list[Any]:
     result: list[Any] = []
     for key in allKeys:
         if key in childKeys:
-            result.append(_readChild(group[key], elemType))
+            result.append(_readChild(group[key], elemType, ctx))
         else:
             result.append(_readAttr(group.attrs[key]))
     return result
 
 
-def _readDictGroup(group: h5py.Group, keyType: Any, valType: Any) -> dict[Any, Any]:
+def _readDictGroup(group: h5py.Group, keyType: Any, valType: Any, ctx: LazyContext | None = None) -> dict[Any, Any]:
     """Read a dict from a group (recursive). Keys are converted from strings."""
     result: dict[Any, Any] = {}
 
@@ -490,7 +490,7 @@ def _readDictGroup(group: h5py.Group, keyType: Any, valType: Any) -> dict[Any, A
         if strKey == _VERSIONABLE_GROUP:
             continue
         key = _strToKey(strKey, keyType)
-        result[key] = _readChild(group[strKey], valType)
+        result[key] = _readChild(group[strKey], valType, ctx)
 
     # Read attributes (scalar dict values are stored as attrs on the subgroup)
     for strKey in group.attrs:
@@ -500,14 +500,14 @@ def _readDictGroup(group: h5py.Group, keyType: Any, valType: Any) -> dict[Any, A
     return result
 
 
-def _readChild(item: h5py.Dataset | h5py.Group, elemType: Any) -> Any:
+def _readChild(item: h5py.Dataset | h5py.Group, elemType: Any, ctx: LazyContext | None = None) -> Any:
     """Read a single child item (dataset or group) with recursive dispatch."""
     if isinstance(item, h5py.Dataset):
         return _readDataset(item, elemType)
     if isinstance(item, h5py.Group):
         if _VERSIONABLE_GROUP in item:
-            return _readVersionableGroup(item, elemType)
-        return _readGroup(item, elemType)
+            return _readVersionableGroup(item, elemType, ctx)
+        return _readGroup(item, elemType, ctx)
     return None
 
 

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -27,6 +27,7 @@ import typing
 from enum import Enum
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import unquote
 
 import h5py
 import numpy as np
@@ -78,7 +79,12 @@ class Hdf5Backend(Backend):
                 meta = _readMeta(f)
                 objectName = meta["__OBJECT__"]
                 cls = _resolveClass(objectName)
-                fieldTypes = _resolveFields(cls) if cls is not None else {}
+                if cls is None:
+                    raise BackendError(
+                        f"Unknown Versionable type {objectName!r} in {path}. "
+                        f"Ensure the class is imported and registered."
+                    )
+                fieldTypes = _resolveFields(cls)
                 fields = _readFields(f, fieldTypes)
             return fields, meta
         except OSError as e:
@@ -147,7 +153,7 @@ class Hdf5Backend(Backend):
                             elif preloadAll or key in preloadSet:
                                 fields[key] = _readGroup(item, fieldType)
                             else:
-                                fields[key] = _makeLazyCollection(path, key, item, fieldType)
+                                fields[key] = _makeLazyCollection(path, item, fieldType)
                                 lazyFields.add(key)
                         else:
                             # Other groups (list[Versionable], etc.) — eager
@@ -302,12 +308,29 @@ def _writeDict(
 
 
 def _keyToStr(key: Any) -> str:
-    """Convert a dict key to a string for use as an HDF5 group/dataset name."""
+    """Convert a dict key to a string for use as an HDF5 group/dataset name.
+
+    Forward slashes are percent-encoded (``%2F``) since HDF5 interprets ``/``
+    as a path separator. Percent signs are also encoded to keep the escaping
+    reversible. Null bytes and empty keys are rejected.
+    """
     if isinstance(key, str):
-        return key
-    if isinstance(key, Enum):
-        return str(key.value)
-    return str(key)
+        result = key
+    elif isinstance(key, Enum):
+        result = str(key.value)
+    else:
+        result = str(key)
+    if not result:
+        raise BackendError("Dict key is empty after string conversion — HDF5 requires non-empty names.")
+    if "\0" in result:
+        raise BackendError(f"Dict key {result!r} contains null bytes — not supported in HDF5 names.")
+    # Percent-encode % and / (the only chars HDF5 interprets specially).
+    # "." as a bare key means "current group" in HDF5, so encode it too.
+    # Decoded with urllib.parse.unquote in _strToKey (single-pass, handles %25 correctly).
+    encoded = result.replace("%", "%25").replace("/", "%2F")
+    if encoded == ".":
+        encoded = "%2E"
+    return encoded
 
 
 def _writeVersionable(
@@ -481,6 +504,9 @@ def _readChild(item: h5py.Dataset | h5py.Group, elemType: Any) -> Any:
 
 def _strToKey(strKey: str, keyType: Any) -> Any:
     """Convert a string HDF5 key back to the original dict key type."""
+    # Reverse percent-encoding in a single pass (handles %25 → % correctly)
+    strKey = unquote(strKey)
+
     if keyType is str or keyType is None:
         return strKey
     if keyType is int:
@@ -552,17 +578,20 @@ def _isArrayCollectionField(fieldType: Any) -> bool:
     return False
 
 
-def _makeLazyCollection(path: Path, key: str, group: h5py.Group, fieldType: Any) -> Any:
+def _makeLazyCollection(path: Path, group: h5py.Group, fieldType: Any) -> Any:
     """Create a LazyArrayList or LazyArrayDict for an array collection group."""
     from versionable._lazy import LazyArrayDict, LazyArrayList
+
+    # Use the full HDF5 group path so nested Versionable fields resolve correctly
+    groupPath = group.name.lstrip("/")
 
     origin = typing.get_origin(fieldType)
     if origin is list:
         keys = sorted(group.keys(), key=int)
-        return LazyArrayList(path, key, keys)
+        return LazyArrayList(path, groupPath, keys)
     if origin is dict:
         keys = list(group.keys())
-        return LazyArrayDict(path, key, keys)
+        return LazyArrayDict(path, groupPath, keys)
     # Shouldn't get here — _isArrayCollectionField guards the call
     return _readGroup(group, fieldType)
 
@@ -579,7 +608,13 @@ def _isArrayField(fieldType: Any) -> bool:
 
 
 def _isNdarrayType(fieldType: Any) -> bool:
-    """Check if a type annotation refers to np.ndarray."""
+    """Check if a type annotation refers to np.ndarray.
+
+    Handles three forms:
+    - Bare: ``np.ndarray``
+    - Typed: ``npt.NDArray[np.float64]`` → origin is ``np.ndarray``
+    - Annotated: ``Annotated[np.ndarray, ...]`` → first arg is ``np.ndarray``
+    """
     origin = typing.get_origin(fieldType)
     if origin is np.ndarray:
         return True

--- a/src/versionable/_json_backend.py
+++ b/src/versionable/_json_backend.py
@@ -1,8 +1,7 @@
 """JSON storage backend.
 
 Stores Versionable objects as pretty-printed JSON with metadata
-envelope (``__VERSION__``, ``__HASH__``, ``__OBJECT__``).  Numpy arrays
-are serialized inline as base64-compressed npz.
+envelope.  Numpy arrays are serialized inline as base64-compressed npz.
 """
 
 from __future__ import annotations
@@ -35,9 +34,11 @@ class JsonBackend(Backend):
         fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
 
         data = {
-            "__OBJECT__": meta["name"],
-            "__VERSION__": meta["version"],
-            "__HASH__": meta["hash"],
+            "__versionable__": {
+                "__OBJECT__": meta["name"],
+                "__VERSION__": meta["version"],
+                "__HASH__": meta["hash"],
+            },
             **fields,
         }
         try:
@@ -55,13 +56,15 @@ class JsonBackend(Backend):
         if not isinstance(data, dict):
             raise BackendError(f"Expected JSON object in {path}, got {type(data).__name__}")
 
+        metaTable = data.pop("__versionable__", {})
+        if not isinstance(metaTable, dict):
+            raise BackendError(f"Missing or invalid __versionable__ metadata in {path}")
+
         meta = {
-            "__OBJECT__": data.pop("__OBJECT__", ""),
-            "__VERSION__": data.pop("__VERSION__", None),
-            "__HASH__": data.pop("__HASH__", ""),
+            "__OBJECT__": metaTable.get("__OBJECT__", ""),
+            "__VERSION__": metaTable.get("__VERSION__"),
+            "__HASH__": metaTable.get("__HASH__", ""),
         }
-        # Also remove __COMPAT__ if present
-        data.pop("__COMPAT__", None)
 
         return data, meta
 

--- a/src/versionable/_json_backend.py
+++ b/src/versionable/_json_backend.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from versionable._backend import Backend, registerBackend
+from versionable._base import _resolveFields
+from versionable._types import serialize
 from versionable.errors import BackendError
 
 
@@ -25,8 +27,13 @@ class JsonBackend(Backend):
         fields: dict[str, Any],
         meta: dict[str, Any],
         path: Path,
+        *,
+        cls: type,
         **kwargs: Any,
     ) -> None:
+        fieldTypes = _resolveFields(cls)
+        fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
+
         data = {
             "__OBJECT__": meta["name"],
             "__VERSION__": meta["version"],

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -52,9 +52,14 @@ def isLazySentinel(value: Any) -> bool:
 class LazyArray:
     """Sentinel that loads an HDF5 dataset on first access.
 
+    Has ``_isLazySentinel = True`` so generic code can detect lazy sentinels
+    without importing this module.
+
     Stores the file path and dataset name; loads and returns the
     numpy array when ``load()`` is called.
     """
+
+    _isLazySentinel = True
 
     def __init__(self, filePath: Path, datasetPath: str) -> None:
         self.filePath = filePath
@@ -72,9 +77,11 @@ class LazyArray:
 class LazyArrayList:
     """A list-like container where each element is lazily loaded from HDF5.
 
-    Supports ``len()``, indexing, iteration, and ``preloadAll()`` to eagerly
-    load everything at once.  Each element is loaded and cached on first access.
+    Supports ``len()``, indexing, iteration, and slicing.
+    Each element is loaded and cached on first access.
     """
+
+    _isLazySentinel = True
 
     def __init__(self, filePath: Path, groupPath: str, keys: list[str]) -> None:
         self.filePath = filePath
@@ -120,6 +127,8 @@ class LazyArrayDict:
     Supports ``len()``, key access, ``keys()``, ``values()``, ``items()``,
     and iteration.  Each value is loaded and cached on first access.
     """
+
+    _isLazySentinel = True
 
     def __init__(
         self,
@@ -171,6 +180,8 @@ class LazyArrayDict:
 
 class ArrayNotLoaded:
     """Sentinel for ``metadataOnly=True`` — raises on access."""
+
+    _isLazySentinel = True
 
     def __init__(self, fieldName: str) -> None:
         self.fieldName = fieldName

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -101,10 +101,19 @@ class LazyArrayDict:
     and iteration.  Each value is loaded and cached on first access.
     """
 
-    def __init__(self, filePath: Path, groupPath: str, keys: list[str]) -> None:
+    def __init__(
+        self,
+        filePath: Path,
+        groupPath: str,
+        keys: list[str],
+        hdf5Keys: list[str] | None = None,
+    ) -> None:
         self.filePath = filePath
         self.groupPath = groupPath
         self._keys = keys
+        # hdf5Keys are the raw (possibly percent-encoded) names in the file
+        self._hdf5Keys = hdf5Keys or keys
+        self._keyToHdf5: dict[str, str] = dict(zip(self._keys, self._hdf5Keys, strict=True))
         self._cache: dict[str, np.ndarray] = {}
 
     def __len__(self) -> int:
@@ -112,11 +121,12 @@ class LazyArrayDict:
 
     def __getitem__(self, key: str) -> np.ndarray:
         if key not in self._cache:
-            if key not in self._keys:
+            if key not in self._keyToHdf5:
                 raise KeyError(key)
+            hdf5Key = self._keyToHdf5[key]
             with h5py.File(self.filePath, "r") as f:
-                self._cache[key] = f[f"{self.groupPath}/{key}"][()]
-            logger.debug("Lazy-loaded %s/%s", self.groupPath, key)
+                self._cache[key] = f[f"{self.groupPath}/{hdf5Key}"][()]
+            logger.debug("Lazy-loaded %s/%s", self.groupPath, hdf5Key)
         return self._cache[key]
 
     def __contains__(self, key: object) -> bool:

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -16,6 +16,7 @@ The mechanism uses a dynamically created subclass that overrides
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
@@ -27,6 +28,25 @@ if TYPE_CHECKING:
 from versionable.errors import ArrayNotLoadedError
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LazyContext:
+    """Controls lazy loading behavior during HDF5 reads.
+
+    Passed through the recursive read path so every level of the object
+    tree applies the same lazy/eager/metadataOnly policy.
+    """
+
+    path: Path
+    preloadAll: bool = False
+    preloadSet: set[str] = field(default_factory=set)
+    metadataOnly: bool = False
+
+
+def isLazySentinel(value: Any) -> bool:
+    """Check if *value* is a lazy loading sentinel that should skip deserialization."""
+    return isinstance(value, (LazyArray, LazyArrayList, LazyArrayDict, ArrayNotLoaded))
 
 
 class LazyArray:

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -4,6 +4,11 @@ When loading a Versionable from HDF5, array fields are replaced with
 ``LazyArray`` sentinels.  On first access, the sentinel loads the data
 from the HDF5 file and caches it in the instance dict.
 
+For ``list[np.ndarray]`` and ``dict[str, np.ndarray]`` fields,
+``LazyArrayList`` and ``LazyArrayDict`` provide per-element lazy loading:
+the collection structure is known immediately but individual arrays are
+loaded only when accessed.
+
 The mechanism uses a dynamically created subclass that overrides
 ``__getattribute__`` to intercept access to lazy fields.
 """
@@ -12,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import h5py
 
@@ -42,6 +47,96 @@ class LazyArray:
 
     def __repr__(self) -> str:
         return f"LazyArray({self.datasetPath!r})"
+
+
+class LazyArrayList:
+    """A list-like container where each element is lazily loaded from HDF5.
+
+    Supports ``len()``, indexing, iteration, and ``preloadAll()`` to eagerly
+    load everything at once.  Each element is loaded and cached on first access.
+    """
+
+    def __init__(self, filePath: Path, groupPath: str, keys: list[str]) -> None:
+        self.filePath = filePath
+        self.groupPath = groupPath
+        self._keys = keys
+        self._cache: dict[int, np.ndarray] = {}
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+    @overload
+    def __getitem__(self, index: int) -> np.ndarray: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[np.ndarray]: ...
+
+    def __getitem__(self, index: int | slice) -> np.ndarray | list[np.ndarray]:
+        if isinstance(index, slice):
+            return [self[i] for i in range(*index.indices(len(self)))]
+        if index < 0:
+            index += len(self)
+        if index < 0 or index >= len(self):
+            raise IndexError(f"index {index} out of range for LazyArrayList of length {len(self)}")
+        if index not in self._cache:
+            key = self._keys[index]
+            with h5py.File(self.filePath, "r") as f:
+                self._cache[index] = f[f"{self.groupPath}/{key}"][()]
+            logger.debug("Lazy-loaded %s/%s", self.groupPath, key)
+        return self._cache[index]
+
+    def __iter__(self) -> Any:
+        for i in range(len(self)):
+            yield self[i]
+
+    def __repr__(self) -> str:
+        loaded = len(self._cache)
+        return f"LazyArrayList({self.groupPath!r}, {len(self)} items, {loaded} loaded)"
+
+
+class LazyArrayDict:
+    """A dict-like container where each value is lazily loaded from HDF5.
+
+    Supports ``len()``, key access, ``keys()``, ``values()``, ``items()``,
+    and iteration.  Each value is loaded and cached on first access.
+    """
+
+    def __init__(self, filePath: Path, groupPath: str, keys: list[str]) -> None:
+        self.filePath = filePath
+        self.groupPath = groupPath
+        self._keys = keys
+        self._cache: dict[str, np.ndarray] = {}
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        if key not in self._cache:
+            if key not in self._keys:
+                raise KeyError(key)
+            with h5py.File(self.filePath, "r") as f:
+                self._cache[key] = f[f"{self.groupPath}/{key}"][()]
+            logger.debug("Lazy-loaded %s/%s", self.groupPath, key)
+        return self._cache[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._keys
+
+    def __iter__(self) -> Any:
+        return iter(self._keys)
+
+    def keys(self) -> list[str]:
+        return list(self._keys)
+
+    def values(self) -> list[np.ndarray]:
+        return [self[k] for k in self._keys]
+
+    def items(self) -> list[tuple[str, np.ndarray]]:
+        return [(k, self[k]) for k in self._keys]
+
+    def __repr__(self) -> str:
+        loaded = len(self._cache)
+        return f"LazyArrayDict({self.groupPath!r}, {len(self)} items, {loaded} loaded)"
 
 
 class ArrayNotLoaded:

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -134,21 +134,22 @@ class LazyArrayDict:
         self,
         filePath: Path,
         groupPath: str,
-        keys: list[str],
+        keys: list[Any],
         hdf5Keys: list[str] | None = None,
     ) -> None:
         self.filePath = filePath
         self.groupPath = groupPath
         self._keys = keys
+        self._keySet: set[Any] = set(keys)
         # hdf5Keys are the raw (possibly percent-encoded) names in the file
-        self._hdf5Keys = hdf5Keys or keys
-        self._keyToHdf5: dict[str, str] = dict(zip(self._keys, self._hdf5Keys, strict=True))
-        self._cache: dict[str, np.ndarray] = {}
+        self._hdf5Keys = hdf5Keys or [str(k) for k in keys]
+        self._keyToHdf5: dict[Any, str] = dict(zip(self._keys, self._hdf5Keys, strict=True))
+        self._cache: dict[Any, np.ndarray] = {}
 
     def __len__(self) -> int:
         return len(self._keys)
 
-    def __getitem__(self, key: str) -> np.ndarray:
+    def __getitem__(self, key: Any) -> np.ndarray:
         if key not in self._cache:
             if key not in self._keyToHdf5:
                 raise KeyError(key)
@@ -159,18 +160,18 @@ class LazyArrayDict:
         return self._cache[key]
 
     def __contains__(self, key: object) -> bool:
-        return key in self._keys
+        return key in self._keySet
 
     def __iter__(self) -> Any:
         return iter(self._keys)
 
-    def keys(self) -> list[str]:
+    def keys(self) -> list[Any]:
         return list(self._keys)
 
     def values(self) -> list[np.ndarray]:
         return [self[k] for k in self._keys]
 
-    def items(self) -> list[tuple[str, np.ndarray]]:
+    def items(self) -> list[tuple[Any, np.ndarray]]:
         return [(k, self[k]) for k in self._keys]
 
     def __repr__(self) -> str:

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -37,6 +37,8 @@ from typing import Any, ClassVar
 import toml
 
 from versionable._backend import Backend, registerBackend
+from versionable._base import _resolveFields
+from versionable._types import serialize
 from versionable.errors import BackendError
 
 
@@ -50,8 +52,12 @@ class TomlBackend(Backend):
         fields: dict[str, Any],
         meta: dict[str, Any],
         path: Path,
+        *,
+        cls: type,
         **kwargs: Any,
     ) -> None:
+        fieldTypes = _resolveFields(cls)
+        fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
         commentDefaults: bool = kwargs.get("commentDefaults", False)
 
         data: dict[str, Any] = {

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -1,11 +1,11 @@
 """TOML storage backend.
 
 Stores Versionable objects as TOML files.  Metadata is stored in a
-``[__meta__]`` table to avoid conflicts with field names.
+``[__versionable__]`` table to avoid conflicts with field names.
 
 Nested Versionable objects use native TOML table syntax::
 
-    [__meta__]
+    [__versionable__]
     __OBJECT__ = "Config"
     __VERSION__ = 1
 
@@ -61,7 +61,7 @@ class TomlBackend(Backend):
         commentDefaults: bool = kwargs.get("commentDefaults", False)
 
         data: dict[str, Any] = {
-            "__meta__": {
+            "__versionable__": {
                 "__OBJECT__": meta["name"],
                 "__VERSION__": meta["version"],
                 "__HASH__": meta["hash"],
@@ -91,9 +91,9 @@ class TomlBackend(Backend):
         if not isinstance(data, dict):
             raise BackendError(f"Expected TOML table in {path}, got {type(data).__name__}")
 
-        metaTable = data.pop("__meta__", {})
+        metaTable = data.pop("__versionable__", {})
         if not isinstance(metaTable, dict):
-            raise BackendError(f"Expected __meta__ to be a table in {path}, got {type(metaTable).__name__}")
+            raise BackendError(f"Expected __versionable__ to be a table in {path}, got {type(metaTable).__name__}")
         meta = {
             "__OBJECT__": metaTable.get("__OBJECT__", ""),
             "__VERSION__": metaTable.get("__VERSION__"),
@@ -150,7 +150,7 @@ def _fromTomlSafe(value: Any) -> Any:
 def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) -> str:
     """Comment out TOML value lines that match the class defaults.
 
-    The ``[__meta__]`` section is always kept uncommented (required for
+    The ``[__versionable__]`` section is always kept uncommented (required for
     deserialization).  Section headers whose children are *all* defaults
     are also commented out.
     """
@@ -210,7 +210,7 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
             if sectionIdx is not None and sectionAllDefault:
                 result[sectionIdx] = "# " + result[sectionIdx]
 
-            inMetaSection = stripped == "[__meta__]"
+            inMetaSection = stripped == "[__versionable__]"
             sectionIdx = len(result)
             sectionAllDefault = True
             result.append(line)
@@ -221,7 +221,7 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
             result.append(line)
             continue
 
-        # __meta__ section — always keep uncommented
+        # __versionable__ section — always keep uncommented
         if inMetaSection:
             sectionAllDefault = False
             result.append(line)

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -232,7 +232,7 @@ def serialize(value: Any, fieldType: Any, *, nativeTypes: set[type] | None = Non
 _UNHANDLED = object()  # sentinel
 
 
-def _serializeTyped(value: Any, nativeTypes: set[type]) -> Any:  # noqa: PLR0911 — type-dispatch; many returns are inherent
+def _serializeTyped(value: Any, nativeTypes: set[type]) -> Any:
     """Try to serialize based on value type.  Returns _UNHANDLED if not matched."""
     valueType = type(value)
 
@@ -359,7 +359,7 @@ def _deserializeUnion(
     return data
 
 
-def _deserializeConcrete(  # noqa: PLR0911 — type-dispatch; many returns are inherent
+def _deserializeConcrete(
     data: Any,
     concreteType: Any,
     args: tuple[Any, ...],

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -463,8 +463,17 @@ def _serializeVersionable(obj: Versionable) -> dict[str, Any]:
 
 
 def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Versionable:
-    """Deserialize a dict to a Versionable instance."""
+    """Deserialize a dict to a Versionable instance.
+
+    If the dict contains a ``__lazy__`` key (set by the HDF5 backend's
+    recursive lazy reader), lazy sentinels are passed through without
+    deserialization and the instance is wrapped with ``makeLazyInstance``.
+    """
     import dataclasses
+
+    from versionable._lazy import isLazySentinel, makeLazyInstance
+
+    lazyFields: set[str] = data.pop("__lazy__", set())
 
     meta = cls._serializer_meta_
     fields = _resolveFields(cls)
@@ -472,18 +481,27 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
     kwargs: dict[str, Any] = {}
     for fieldName, fieldType in fields.items():
         if fieldName in data:
-            dcField = dcFields.get(fieldName)
-            dcMeta = dcField.metadata if dcField is not None else None
-            kwargs[fieldName] = deserialize(
-                data[fieldName], fieldType, fieldMetadata=dcMeta, validateLiterals=meta.validateLiterals
-            )
+            rawValue = data[fieldName]
+            if fieldName in lazyFields or isLazySentinel(rawValue):
+                # Lazy sentinel — pass through without deserialization
+                kwargs[fieldName] = rawValue
+            else:
+                dcField = dcFields.get(fieldName)
+                dcMeta = dcField.metadata if dcField is not None else None
+                kwargs[fieldName] = deserialize(
+                    rawValue, fieldType, fieldMetadata=dcMeta, validateLiterals=meta.validateLiterals
+                )
         elif fieldName in dcFields:
             dcField = dcFields[fieldName]
             if dcField.default is not dataclasses.MISSING:
                 kwargs[fieldName] = dcField.default
             elif dcField.default_factory is not dataclasses.MISSING:
                 kwargs[fieldName] = dcField.default_factory()
-    return cls(**kwargs)
+
+    instance = cls(**kwargs)
+    if lazyFields:
+        instance = makeLazyInstance(instance, lazyFields)
+    return instance
 
 
 # ---------------------------------------------------------------------------

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -471,8 +471,6 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
     """
     import dataclasses
 
-    from versionable._lazy import isLazySentinel, makeLazyInstance
-
     lazyFields: set[str] = data.pop("__lazy__", set())
 
     meta = cls._serializer_meta_
@@ -482,7 +480,7 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
     for fieldName, fieldType in fields.items():
         if fieldName in data:
             rawValue = data[fieldName]
-            if fieldName in lazyFields or isLazySentinel(rawValue):
+            if fieldName in lazyFields or getattr(rawValue, "_isLazySentinel", False):
                 # Lazy sentinel — pass through without deserialization
                 kwargs[fieldName] = rawValue
             else:
@@ -500,6 +498,8 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
 
     instance = cls(**kwargs)
     if lazyFields:
+        from versionable._lazy import makeLazyInstance
+
         instance = makeLazyInstance(instance, lazyFields)
     return instance
 

--- a/src/versionable/_yaml_backend.py
+++ b/src/versionable/_yaml_backend.py
@@ -1,7 +1,7 @@
 """YAML storage backend.
 
 Stores Versionable objects as YAML files.  Metadata is stored in a
-``__meta__`` mapping to avoid conflicts with field names, matching the
+``__versionable__`` mapping to avoid conflicts with field names, matching the
 TOML backend convention::
 
     name: probe-A
@@ -10,7 +10,7 @@ TOML backend convention::
     - 0
     - 1
     - 2
-    __meta__:
+    __versionable__:
       __OBJECT__: SensorConfig
       __VERSION__: 1
       __HASH__: 9d6951
@@ -53,7 +53,7 @@ class YamlBackend(Backend):
         for key, value in fields.items():
             data[key] = _toYamlSafe(value)
 
-        data["__meta__"] = {
+        data["__versionable__"] = {
             "__OBJECT__": meta["name"],
             "__VERSION__": meta["version"],
             "__HASH__": meta["hash"],
@@ -79,9 +79,9 @@ class YamlBackend(Backend):
         if not isinstance(data, dict):
             raise BackendError(f"Expected YAML mapping in {path}, got {type(data).__name__}")
 
-        metaTable = data.pop("__meta__", {})
+        metaTable = data.pop("__versionable__", {})
         if not isinstance(metaTable, dict):
-            raise BackendError(f"Expected __meta__ to be a mapping in {path}, got {type(metaTable).__name__}")
+            raise BackendError(f"Expected __versionable__ to be a mapping in {path}, got {type(metaTable).__name__}")
         meta = {
             "__OBJECT__": metaTable.get("__OBJECT__", ""),
             "__VERSION__": metaTable.get("__VERSION__"),
@@ -157,7 +157,7 @@ def _findClass(objectName: str) -> type | None:
 def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) -> str:
     """Comment out YAML lines for fields whose values match the class defaults.
 
-    The ``__meta__`` block is always kept uncommented (required for
+    The ``__versionable__`` block is always kept uncommented (required for
     deserialization).  Multi-line values (lists, nested mappings) are
     handled by commenting out the entire indented block under a top-level
     key.
@@ -206,9 +206,9 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
         if stripped and not stripped[0].isspace() and ":" in stripped:
             key = stripped.split(":")[0]
 
-            # Never comment out __meta__
-            if key == "__meta__":
-                # Pass through __meta__ block
+            # Never comment out __versionable__
+            if key == "__versionable__":
+                # Pass through __versionable__ block
                 result.append(lines[i])
                 i += 1
                 while i < len(lines) and lines[i].rstrip("\n") and lines[i][0].isspace():

--- a/src/versionable/_yaml_backend.py
+++ b/src/versionable/_yaml_backend.py
@@ -28,6 +28,8 @@ from typing import Any, ClassVar
 import yaml
 
 from versionable._backend import Backend, registerBackend
+from versionable._base import _resolveFields
+from versionable._types import serialize
 from versionable.errors import BackendError
 
 
@@ -41,8 +43,12 @@ class YamlBackend(Backend):
         fields: dict[str, Any],
         meta: dict[str, Any],
         path: Path,
+        *,
+        cls: type,
         **kwargs: Any,
     ) -> None:
+        fieldTypes = _resolveFields(cls)
+        fields = {k: serialize(v, fieldTypes[k], nativeTypes=self.nativeTypes) for k, v in fields.items()}
         data: dict[str, Any] = {}
         for key, value in fields.items():
             data[key] = _toYamlSafe(value)

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -53,6 +53,7 @@ _h_kitchen_sink = computeHash(
         "color": Color,
         "intPriority": IntPriority,
         "createdAt": datetime.datetime,
+        "createdAtTz": datetime.datetime,
         "today": datetime.date,
         "elapsed": datetime.timedelta,
         "filePath": Path,
@@ -78,6 +79,7 @@ class _KitchenSink(Versionable, version=1, hash=_h_kitchen_sink, register=False)
     color: Color
     intPriority: IntPriority
     createdAt: datetime.datetime
+    createdAtTz: datetime.datetime
     today: datetime.date
     elapsed: datetime.timedelta
     filePath: Path
@@ -236,6 +238,7 @@ class TestKitchenSinkRoundtrip:
             color=Color.GREEN,
             intPriority=IntPriority.HIGH,
             createdAt=datetime.datetime(2024, 6, 15, 14, 30, 0),
+            createdAtTz=datetime.datetime(2024, 6, 15, 14, 30, 0, tzinfo=datetime.UTC),
             today=datetime.date(2024, 6, 15),
             elapsed=datetime.timedelta(hours=2, minutes=30, seconds=15),
             filePath=Path("/data/results"),
@@ -267,6 +270,8 @@ class TestKitchenSinkRoundtrip:
         assert isinstance(loaded.color, Color), f"[{ext}] color type"
         assert isinstance(loaded.intPriority, IntPriority), f"[{ext}] intPriority type"
         assert isinstance(loaded.createdAt, datetime.datetime), f"[{ext}] createdAt type"
+        assert isinstance(loaded.createdAtTz, datetime.datetime), f"[{ext}] createdAtTz type"
+        assert loaded.createdAtTz.tzinfo is not None, f"[{ext}] createdAtTz should be timezone-aware"
         assert isinstance(loaded.today, datetime.date), f"[{ext}] today type"
         assert isinstance(loaded.elapsed, datetime.timedelta), f"[{ext}] elapsed type"
         assert isinstance(loaded.filePath, Path), f"[{ext}] filePath type"

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -111,6 +111,7 @@ except ImportError:
     _HDF5_BACKENDS = []
 
 _ALL_BACKENDS = [*_DICT_BACKENDS, *_HDF5_BACKENDS]
+_NONE_SAFE_BACKENDS = [".json", ".yaml", *_HDF5_BACKENDS]  # TOML omits None
 
 
 def _roundtrip(cls: type, obj: Versionable, tmp_path: Path, ext: str) -> Versionable:
@@ -292,7 +293,7 @@ class TestKitchenSinkRoundtrip:
 class TestOptionalFieldsRoundtrip:
     """None handling across backends."""
 
-    @pytest.mark.parametrize("ext", [".json", ".yaml", ".h5"])
+    @pytest.mark.parametrize("ext", _NONE_SAFE_BACKENDS)
     def test_noneValues(self, tmp_path: Path, ext: str) -> None:
         """None fields roundtrip correctly."""
         obj = _WithOptional(name="test", label=None, count=None)
@@ -300,7 +301,7 @@ class TestOptionalFieldsRoundtrip:
         assert loaded.label is None, f"[{ext}] label should be None"
         assert loaded.count is None, f"[{ext}] count should be None"
 
-    @pytest.mark.parametrize("ext", [".json", ".yaml", ".h5"])
+    @pytest.mark.parametrize("ext", _NONE_SAFE_BACKENDS)
     def test_noneVsNonNone(self, tmp_path: Path, ext: str) -> None:
         """Mix of None and non-None in optional fields."""
         obj = _WithOptional(name="test", label="hello", count=None)

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -1,0 +1,456 @@
+"""Cross-backend roundtrip tests.
+
+Saves objects through every backend and verifies that the loaded data
+matches the original exactly — values, types, and structure.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from typing import Literal
+from uuid import UUID
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import versionable
+from versionable import Versionable
+from versionable._hash import computeHash
+
+# ---------------------------------------------------------------------------
+# Test classes — defined at module level for type-annotation resolution
+# ---------------------------------------------------------------------------
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+class IntPriority(Enum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+
+@dataclass
+class _Inner(Versionable, version=1, hash=computeHash({"x": float, "y": float}), name="CrossInner"):
+    x: float
+    y: float
+
+
+_h_kitchen_sink = computeHash(
+    {
+        "name": str,
+        "count": int,
+        "rate": float,
+        "debug": bool,
+        "color": Color,
+        "intPriority": IntPriority,
+        "createdAt": datetime.datetime,
+        "today": datetime.date,
+        "elapsed": datetime.timedelta,
+        "filePath": Path,
+        "posixPath": PurePosixPath,
+        "uid": UUID,
+        "mode": Literal["fast", "slow"],
+        "tags": list[str],
+        "scores": list[float],
+        "counts": list[int],
+        "flags": list[bool],
+        "nested": _Inner,
+        "points": list[_Inner],
+    }
+)
+
+
+@dataclass
+class _KitchenSink(Versionable, version=1, hash=_h_kitchen_sink, register=False):
+    name: str
+    count: int
+    rate: float
+    debug: bool
+    color: Color
+    intPriority: IntPriority
+    createdAt: datetime.datetime
+    today: datetime.date
+    elapsed: datetime.timedelta
+    filePath: Path
+    posixPath: PurePosixPath
+    uid: UUID
+    mode: Literal["fast", "slow"]
+    tags: list[str]
+    scores: list[float]
+    counts: list[int]
+    flags: list[bool]
+    nested: _Inner
+    points: list[_Inner]
+
+
+_h_with_optional = computeHash(
+    {
+        "name": str,
+        "label": str | None,
+        "count": int | None,
+    }
+)
+
+
+@dataclass
+class _WithOptional(Versionable, version=1, hash=_h_with_optional, register=False):
+    name: str
+    label: str | None = None
+    count: int | None = None
+
+
+_h_with_arrays = computeHash(
+    {
+        "name": str,
+        "data": npt.NDArray[np.float64],
+        "matrix": npt.NDArray[np.int32],
+        "traces": list[npt.NDArray[np.float64]],
+        "channels": dict[str, npt.NDArray[np.float64]],
+    }
+)
+
+
+@dataclass
+class _WithArrays(Versionable, version=1, hash=_h_with_arrays, register=False):
+    name: str
+    data: npt.NDArray[np.float64]
+    matrix: npt.NDArray[np.int32]
+    traces: list[npt.NDArray[np.float64]]
+    channels: dict[str, npt.NDArray[np.float64]]
+
+
+_h_empty_collections = computeHash(
+    {
+        "tags": list[str],
+        "scores": list[float],
+        "counts": list[int],
+    }
+)
+
+
+@dataclass
+class _EmptyCollections(Versionable, version=1, hash=_h_empty_collections, register=False):
+    tags: list[str] = field(default_factory=list)
+    scores: list[float] = field(default_factory=list)
+    counts: list[int] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Backend extensions
+# ---------------------------------------------------------------------------
+
+_DICT_BACKENDS = [".json", ".yaml", ".toml"]
+_ALL_BACKENDS = [".json", ".yaml", ".toml", ".h5"]
+
+
+def _roundtrip(cls: type, obj: Versionable, tmp_path: Path, ext: str) -> Versionable:
+    """Save and reload through a specific backend."""
+    p = tmp_path / f"roundtrip{ext}"
+    versionable.save(obj, p)
+    return versionable.load(cls, p, preload="*")
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def _assertFieldMatch(original: object, loaded: object, fieldName: str, ext: str) -> None:
+    """Assert that a single field value and type match after roundtrip."""
+    orig = getattr(original, fieldName)
+    load = getattr(loaded, fieldName)
+
+    if isinstance(orig, np.ndarray):
+        assert isinstance(load, np.ndarray), f"[{ext}] {fieldName}: expected np.ndarray, got {type(load).__name__}"
+        np.testing.assert_array_equal(load, orig, err_msg=f"[{ext}] {fieldName}")
+        assert load.dtype == orig.dtype, f"[{ext}] {fieldName}: dtype mismatch {load.dtype} != {orig.dtype}"
+        return
+
+    if isinstance(orig, list) and orig and isinstance(orig[0], np.ndarray):
+        assert isinstance(load, list), f"[{ext}] {fieldName}: expected list, got {type(load).__name__}"
+        assert len(load) == len(orig), f"[{ext}] {fieldName}: length mismatch {len(load)} != {len(orig)}"
+        for i, (origArr, loadArr) in enumerate(zip(orig, load, strict=True)):
+            np.testing.assert_array_equal(loadArr, origArr, err_msg=f"[{ext}] {fieldName}[{i}]")
+        return
+
+    if isinstance(orig, dict) and orig and isinstance(next(iter(orig.values())), np.ndarray):
+        assert isinstance(load, dict), f"[{ext}] {fieldName}: expected dict, got {type(load).__name__}"
+        assert set(load.keys()) == set(orig.keys()), f"[{ext}] {fieldName}: key mismatch"
+        for k in orig:
+            np.testing.assert_array_equal(load[k], orig[k], err_msg=f"[{ext}] {fieldName}[{k!r}]")
+        return
+
+    assert load == orig, f"[{ext}] {fieldName}: value mismatch {load!r} != {orig!r}"
+    assert type(load) is type(orig), (
+        f"[{ext}] {fieldName}: type mismatch {type(load).__name__} != {type(orig).__name__}"
+    )
+
+
+def _assertFullMatch(original: Versionable, loaded: Versionable, ext: str) -> None:
+    """Assert all fields match between original and loaded."""
+    from versionable._base import _resolveFields
+
+    fields = _resolveFields(type(original))
+    for fieldName in fields:
+        orig = getattr(original, fieldName)
+        load = getattr(loaded, fieldName)
+
+        # Recurse into nested Versionables
+        if isinstance(orig, Versionable):
+            assert isinstance(load, type(orig)), (
+                f"[{ext}] {fieldName}: expected {type(orig).__name__}, got {type(load).__name__}"
+            )
+            _assertFullMatch(orig, load, ext)
+        elif isinstance(orig, list) and orig and isinstance(orig[0], Versionable):
+            assert len(load) == len(orig), f"[{ext}] {fieldName}: length mismatch"
+            for i, (origItem, loadItem) in enumerate(zip(orig, load, strict=True)):
+                _assertFullMatch(origItem, loadItem, f"{ext}/{fieldName}[{i}]")
+        else:
+            _assertFieldMatch(original, loaded, fieldName, ext)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestKitchenSinkRoundtrip:
+    """Every common type through every backend."""
+
+    @pytest.fixture
+    def obj(self) -> _KitchenSink:
+        return _KitchenSink(
+            name="experiment-1",
+            count=42,
+            rate=3.14159265358979,
+            debug=True,
+            color=Color.GREEN,
+            intPriority=IntPriority.HIGH,
+            createdAt=datetime.datetime(2024, 6, 15, 14, 30, 0),
+            today=datetime.date(2024, 6, 15),
+            elapsed=datetime.timedelta(hours=2, minutes=30, seconds=15),
+            filePath=Path("/data/results"),
+            posixPath=PurePosixPath("/opt/config"),
+            uid=UUID("12345678-1234-5678-1234-567812345678"),
+            mode="slow",
+            tags=["alpha", "beta", "gamma"],
+            scores=[1.0, 2.5, 3.7],
+            counts=[10, 20, 30],
+            flags=[True, False, True],
+            nested=_Inner(x=1.5, y=-2.5),
+            points=[_Inner(x=0.0, y=0.0), _Inner(x=1.0, y=1.0)],
+        )
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_allFieldsRoundtrip(self, obj: _KitchenSink, tmp_path: Path, ext: str) -> None:
+        loaded = _roundtrip(_KitchenSink, obj, tmp_path, ext)
+        _assertFullMatch(obj, loaded, ext)
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_exactTypes(self, obj: _KitchenSink, tmp_path: Path, ext: str) -> None:
+        """Verify that deserialized types are exact Python types, not surrogates."""
+        loaded = _roundtrip(_KitchenSink, obj, tmp_path, ext)
+
+        assert type(loaded.name) is str, f"[{ext}] name type"
+        assert type(loaded.count) is int, f"[{ext}] count type"
+        assert type(loaded.rate) is float, f"[{ext}] rate type"
+        assert type(loaded.debug) is bool, f"[{ext}] debug type"
+        assert isinstance(loaded.color, Color), f"[{ext}] color type"
+        assert isinstance(loaded.intPriority, IntPriority), f"[{ext}] intPriority type"
+        assert isinstance(loaded.createdAt, datetime.datetime), f"[{ext}] createdAt type"
+        assert isinstance(loaded.today, datetime.date), f"[{ext}] today type"
+        assert isinstance(loaded.elapsed, datetime.timedelta), f"[{ext}] elapsed type"
+        assert isinstance(loaded.filePath, Path), f"[{ext}] filePath type"
+        assert isinstance(loaded.posixPath, PurePosixPath), f"[{ext}] posixPath type"
+        assert isinstance(loaded.uid, UUID), f"[{ext}] uid type"
+        assert type(loaded.mode) is str, f"[{ext}] mode type"
+        assert isinstance(loaded.tags, list), f"[{ext}] tags type"
+        assert isinstance(loaded.scores, list), f"[{ext}] scores type"
+        assert isinstance(loaded.counts, list), f"[{ext}] counts type"
+        assert isinstance(loaded.flags, list), f"[{ext}] flags type"
+        assert isinstance(loaded.nested, _Inner), f"[{ext}] nested type"
+        assert isinstance(loaded.points, list), f"[{ext}] points type"
+        assert all(isinstance(p, _Inner) for p in loaded.points), f"[{ext}] points element type"
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_listElementTypes(self, obj: _KitchenSink, tmp_path: Path, ext: str) -> None:
+        """Verify that list elements have the correct Python types."""
+        loaded = _roundtrip(_KitchenSink, obj, tmp_path, ext)
+
+        for tag in loaded.tags:
+            assert type(tag) is str, f"[{ext}] tag element type: {type(tag)}"
+        for score in loaded.scores:
+            assert type(score) is float, f"[{ext}] score element type: {type(score)}"
+        for count in loaded.counts:
+            assert type(count) is int, f"[{ext}] count element type: {type(count)}"
+        for flag in loaded.flags:
+            assert type(flag) is bool, f"[{ext}] flag element type: {type(flag)}"
+
+
+class TestOptionalFieldsRoundtrip:
+    """None handling across backends."""
+
+    @pytest.mark.parametrize("ext", [".json", ".yaml", ".h5"])
+    def test_noneValues(self, tmp_path: Path, ext: str) -> None:
+        """None fields roundtrip correctly."""
+        obj = _WithOptional(name="test", label=None, count=None)
+        loaded = _roundtrip(_WithOptional, obj, tmp_path, ext)
+        assert loaded.label is None, f"[{ext}] label should be None"
+        assert loaded.count is None, f"[{ext}] count should be None"
+
+    @pytest.mark.parametrize("ext", [".json", ".yaml", ".h5"])
+    def test_noneVsNonNone(self, tmp_path: Path, ext: str) -> None:
+        """Mix of None and non-None in optional fields."""
+        obj = _WithOptional(name="test", label="hello", count=None)
+        loaded = _roundtrip(_WithOptional, obj, tmp_path, ext)
+        assert loaded.label == "hello", f"[{ext}] label value"
+        assert type(loaded.label) is str, f"[{ext}] label type"
+        assert loaded.count is None, f"[{ext}] count should be None"
+
+    def test_tomlOmitsNone(self, tmp_path: Path) -> None:
+        """TOML omits None fields; they restore from defaults."""
+        obj = _WithOptional(name="test", label=None, count=None)
+        loaded = _roundtrip(_WithOptional, obj, tmp_path, ".toml")
+        # TOML omits None → dataclass default (also None) kicks in
+        assert loaded.label is None
+        assert loaded.count is None
+
+
+class TestArrayFieldsRoundtrip:
+    """Array and array-collection fields across backends."""
+
+    @pytest.fixture
+    def obj(self) -> _WithArrays:
+        return _WithArrays(
+            name="arrays",
+            data=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            matrix=np.array([[1, 2], [3, 4]], dtype=np.int32),
+            traces=[np.array([10.0, 20.0]), np.array([30.0, 40.0, 50.0])],
+            channels={"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])},
+        )
+
+    def test_hdf5Roundtrip(self, obj: _WithArrays, tmp_path: Path) -> None:
+        loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
+        _assertFullMatch(obj, loaded, ".h5")
+
+    @pytest.mark.parametrize("ext", _DICT_BACKENDS)
+    def test_dictBackendRoundtrip(self, obj: _WithArrays, tmp_path: Path, ext: str) -> None:
+        """Dict backends serialize arrays as base64 npz and roundtrip correctly."""
+        loaded = _roundtrip(_WithArrays, obj, tmp_path, ext)
+        np.testing.assert_array_equal(loaded.data, obj.data)
+        assert loaded.data.dtype == obj.data.dtype
+        np.testing.assert_array_equal(loaded.matrix, obj.matrix)
+        assert loaded.matrix.dtype == obj.matrix.dtype
+
+    def test_hdf5ArrayDtypes(self, obj: _WithArrays, tmp_path: Path) -> None:
+        """HDF5 preserves exact dtypes."""
+        loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
+        assert loaded.data.dtype == np.float64
+        assert loaded.matrix.dtype == np.int32
+
+
+class TestNumpyDtypeRoundtrip:
+    """Verify that various numpy dtypes survive the roundtrip."""
+
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.float32,
+            np.float64,
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.bool_,
+            np.complex64,
+            np.complex128,
+        ],
+    )
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_scalarDtype(self, tmp_path: Path, dtype: type, ext: str) -> None:
+        """1-D array of each dtype roundtrips with correct dtype."""
+        h = computeHash({"arr": npt.NDArray[np.generic]})
+
+        @dataclass
+        class DtypeTest(Versionable, version=1, hash=h, register=False):
+            arr: npt.NDArray[np.generic]
+
+        arr = np.array([1, 2, 3], dtype=dtype)
+        obj = DtypeTest(arr=arr)
+        loaded = _roundtrip(DtypeTest, obj, tmp_path, ext)
+        np.testing.assert_array_equal(loaded.arr, arr)
+        assert loaded.arr.dtype == dtype, f"[{ext}] dtype: {loaded.arr.dtype} != {dtype}"
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_2dArray(self, tmp_path: Path, ext: str) -> None:
+        """2-D array preserves shape and dtype."""
+        h = computeHash({"matrix": npt.NDArray[np.float64]})
+
+        @dataclass
+        class Matrix(Versionable, version=1, hash=h, register=False):
+            matrix: npt.NDArray[np.float64]
+
+        arr = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+        obj = Matrix(matrix=arr)
+        loaded = _roundtrip(Matrix, obj, tmp_path, ext)
+        np.testing.assert_array_equal(loaded.matrix, arr)
+        assert loaded.matrix.shape == (3, 2), f"[{ext}] shape: {loaded.matrix.shape}"
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_3dArray(self, tmp_path: Path, ext: str) -> None:
+        """3-D array preserves shape."""
+        h = computeHash({"cube": npt.NDArray[np.float32]})
+
+        @dataclass
+        class Cube(Versionable, version=1, hash=h, register=False):
+            cube: npt.NDArray[np.float32]
+
+        arr = np.ones((2, 3, 4), dtype=np.float32)
+        obj = Cube(cube=arr)
+        loaded = _roundtrip(Cube, obj, tmp_path, ext)
+        np.testing.assert_array_equal(loaded.cube, arr)
+        assert loaded.cube.shape == (2, 3, 4), f"[{ext}] shape: {loaded.cube.shape}"
+        assert loaded.cube.dtype == np.float32, f"[{ext}] dtype: {loaded.cube.dtype}"
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_emptyArray(self, tmp_path: Path, ext: str) -> None:
+        """Zero-length array preserves dtype."""
+        h = computeHash({"arr": npt.NDArray[np.float64]})
+
+        @dataclass
+        class EmptyArr(Versionable, version=1, hash=h, register=False):
+            arr: npt.NDArray[np.float64]
+
+        arr = np.array([], dtype=np.float64)
+        obj = EmptyArr(arr=arr)
+        loaded = _roundtrip(EmptyArr, obj, tmp_path, ext)
+        assert len(loaded.arr) == 0
+        assert loaded.arr.dtype == np.float64, f"[{ext}] dtype: {loaded.arr.dtype}"
+
+
+class TestEmptyCollectionsRoundtrip:
+    """Empty lists across backends."""
+
+    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+    def test_emptyLists(self, tmp_path: Path, ext: str) -> None:
+        obj = _EmptyCollections(tags=[], scores=[], counts=[])
+        loaded = _roundtrip(_EmptyCollections, obj, tmp_path, ext)
+        assert loaded.tags == []
+        assert loaded.scores == []
+        assert loaded.counts == []
+        assert isinstance(loaded.tags, list)
+        assert isinstance(loaded.scores, list)
+        assert isinstance(loaded.counts, list)

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -102,7 +102,15 @@ class _EmptyCollections(Versionable, version=1, hash="6c8e40", register=False):
 # ---------------------------------------------------------------------------
 
 _DICT_BACKENDS = [".json", ".yaml", ".toml"]
-_ALL_BACKENDS = [".json", ".yaml", ".toml", ".h5"]
+
+try:
+    import versionable._hdf5_backend
+
+    _HDF5_BACKENDS: list[str] = [".h5"]
+except ImportError:
+    _HDF5_BACKENDS = []
+
+_ALL_BACKENDS = [*_DICT_BACKENDS, *_HDF5_BACKENDS]
 
 
 def _roundtrip(cls: type, obj: Versionable, tmp_path: Path, ext: str) -> Versionable:
@@ -323,6 +331,7 @@ class TestArrayFieldsRoundtrip:
             channels={"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])},
         )
 
+    @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
     def test_hdf5Roundtrip(self, obj: _WithArrays, tmp_path: Path) -> None:
         loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
         _assertFullMatch(obj, loaded, ".h5")
@@ -336,6 +345,7 @@ class TestArrayFieldsRoundtrip:
         np.testing.assert_array_equal(loaded.matrix, obj.matrix)
         assert loaded.matrix.dtype == obj.matrix.dtype
 
+    @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
     def test_hdf5ArrayDtypes(self, obj: _WithArrays, tmp_path: Path) -> None:
         """HDF5 preserves exact dtypes."""
         loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -39,39 +39,13 @@ class IntPriority(Enum):
 
 
 @dataclass
-class _Inner(Versionable, version=1, hash=computeHash({"x": float, "y": float}), name="CrossInner"):
+class _Inner(Versionable, version=1, hash="e37514", name="CrossInner"):
     x: float
     y: float
 
 
-_h_kitchen_sink = computeHash(
-    {
-        "name": str,
-        "count": int,
-        "rate": float,
-        "debug": bool,
-        "color": Color,
-        "intPriority": IntPriority,
-        "createdAt": datetime.datetime,
-        "createdAtTz": datetime.datetime,
-        "today": datetime.date,
-        "elapsed": datetime.timedelta,
-        "filePath": Path,
-        "posixPath": PurePosixPath,
-        "uid": UUID,
-        "mode": Literal["fast", "slow"],
-        "tags": list[str],
-        "scores": list[float],
-        "counts": list[int],
-        "flags": list[bool],
-        "nested": _Inner,
-        "points": list[_Inner],
-    }
-)
-
-
 @dataclass
-class _KitchenSink(Versionable, version=1, hash=_h_kitchen_sink, register=False):
+class _KitchenSink(Versionable, version=1, hash="3b5a61", register=False):
     name: str
     count: int
     rate: float
@@ -90,39 +64,25 @@ class _KitchenSink(Versionable, version=1, hash=_h_kitchen_sink, register=False)
     scores: list[float]
     counts: list[int]
     flags: list[bool]
+    uniqueTags: set[str]
+    frozenIds: frozenset[int]
+    coords: tuple[float, ...]
+    metadata: dict[str, int]
+    indexedLabels: dict[int, str]
     nested: _Inner
     points: list[_Inner]
-
-
-_h_with_optional = computeHash(
-    {
-        "name": str,
-        "label": str | None,
-        "count": int | None,
-    }
-)
+    channelData: dict[str, list[float]]
 
 
 @dataclass
-class _WithOptional(Versionable, version=1, hash=_h_with_optional, register=False):
+class _WithOptional(Versionable, version=1, hash="c599a5", register=False):
     name: str
     label: str | None = None
     count: int | None = None
 
 
-_h_with_arrays = computeHash(
-    {
-        "name": str,
-        "data": npt.NDArray[np.float64],
-        "matrix": npt.NDArray[np.int32],
-        "traces": list[npt.NDArray[np.float64]],
-        "channels": dict[str, npt.NDArray[np.float64]],
-    }
-)
-
-
 @dataclass
-class _WithArrays(Versionable, version=1, hash=_h_with_arrays, register=False):
+class _WithArrays(Versionable, version=1, hash="e9fc06", register=False):
     name: str
     data: npt.NDArray[np.float64]
     matrix: npt.NDArray[np.int32]
@@ -130,17 +90,8 @@ class _WithArrays(Versionable, version=1, hash=_h_with_arrays, register=False):
     channels: dict[str, npt.NDArray[np.float64]]
 
 
-_h_empty_collections = computeHash(
-    {
-        "tags": list[str],
-        "scores": list[float],
-        "counts": list[int],
-    }
-)
-
-
 @dataclass
-class _EmptyCollections(Versionable, version=1, hash=_h_empty_collections, register=False):
+class _EmptyCollections(Versionable, version=1, hash="6c8e40", register=False):
     tags: list[str] = field(default_factory=list)
     scores: list[float] = field(default_factory=list)
     counts: list[int] = field(default_factory=list)
@@ -249,8 +200,14 @@ class TestKitchenSinkRoundtrip:
             scores=[1.0, 2.5, 3.7],
             counts=[10, 20, 30],
             flags=[True, False, True],
+            uniqueTags={"x", "y", "z"},
+            frozenIds=frozenset({10, 20, 30}),
+            coords=(1.0, 2.0, 3.0),
+            metadata={"width": 100, "height": 200},
+            indexedLabels={0: "first", 1: "second"},
             nested=_Inner(x=1.5, y=-2.5),
             points=[_Inner(x=0.0, y=0.0), _Inner(x=1.0, y=1.0)],
+            channelData={"ch0": [1.0, 2.0, 3.0], "ch1": [4.0, 5.0]},
         )
 
     @pytest.mark.parametrize("ext", _ALL_BACKENDS)
@@ -282,9 +239,15 @@ class TestKitchenSinkRoundtrip:
         assert isinstance(loaded.scores, list), f"[{ext}] scores type"
         assert isinstance(loaded.counts, list), f"[{ext}] counts type"
         assert isinstance(loaded.flags, list), f"[{ext}] flags type"
+        assert isinstance(loaded.uniqueTags, set), f"[{ext}] uniqueTags type"
+        assert isinstance(loaded.frozenIds, frozenset), f"[{ext}] frozenIds type"
+        assert isinstance(loaded.coords, tuple), f"[{ext}] coords type"
+        assert isinstance(loaded.metadata, dict), f"[{ext}] metadata type"
+        assert isinstance(loaded.indexedLabels, dict), f"[{ext}] indexedLabels type"
         assert isinstance(loaded.nested, _Inner), f"[{ext}] nested type"
         assert isinstance(loaded.points, list), f"[{ext}] points type"
         assert all(isinstance(p, _Inner) for p in loaded.points), f"[{ext}] points element type"
+        assert isinstance(loaded.channelData, dict), f"[{ext}] channelData type"
 
     @pytest.mark.parametrize("ext", _ALL_BACKENDS)
     def test_listElementTypes(self, obj: _KitchenSink, tmp_path: Path, ext: str) -> None:
@@ -299,6 +262,23 @@ class TestKitchenSinkRoundtrip:
             assert type(count) is int, f"[{ext}] count element type: {type(count)}"
         for flag in loaded.flags:
             assert type(flag) is bool, f"[{ext}] flag element type: {type(flag)}"
+        for tag in loaded.uniqueTags:
+            assert type(tag) is str, f"[{ext}] uniqueTags element type: {type(tag)}"
+        for val in loaded.frozenIds:
+            assert type(val) is int, f"[{ext}] frozenIds element type: {type(val)}"
+        for val in loaded.coords:
+            assert type(val) is float, f"[{ext}] coords element type: {type(val)}"
+        for k, v in loaded.metadata.items():
+            assert type(k) is str, f"[{ext}] metadata key type: {type(k)}"
+            assert type(v) is int, f"[{ext}] metadata value type: {type(v)}"
+        for k, v in loaded.indexedLabels.items():
+            assert type(k) is int, f"[{ext}] indexedLabels key type: {type(k)}"
+            assert type(v) is str, f"[{ext}] indexedLabels value type: {type(v)}"
+        for k, v in loaded.channelData.items():
+            assert type(k) is str, f"[{ext}] channelData key type: {type(k)}"
+            assert isinstance(v, list), f"[{ext}] channelData value type: {type(v)}"
+            for elem in v:
+                assert type(elem) is float, f"[{ext}] channelData element type: {type(elem)}"
 
 
 class TestOptionalFieldsRoundtrip:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -46,6 +46,24 @@ class _Measurement(Versionable, version=1, hash=_h_measurement, name="Measuremen
     data: npt.NDArray[np.float64]
 
 
+_h_with_traces = computeHash({"name": str, "traces": list[npt.NDArray[np.float64]]})
+
+
+@dataclass
+class _WithTraces(Versionable, version=1, hash=_h_with_traces, register=False):
+    name: str
+    traces: list[npt.NDArray[np.float64]]
+
+
+_h_with_channels = computeHash({"name": str, "channels": dict[str, npt.NDArray[np.float64]]})
+
+
+@dataclass
+class _WithChannels(Versionable, version=1, hash=_h_with_channels, register=False):
+    name: str
+    channels: dict[str, npt.NDArray[np.float64]]
+
+
 _h_experiment = computeHash({"name": str, "measurements": list[_Measurement]})
 
 
@@ -642,6 +660,111 @@ class TestNativeNoJson:
         with h5py.File(p, "r") as f:
             assert "__scalars__" not in f.attrs
             _assertNoJsonAttrs(f)
+
+
+class TestLazyArrayCollections:
+    """Test per-element lazy loading for list[ndarray] and dict[str, ndarray]."""
+
+    def test_listNdarrayLazy(self, tmp_path: Path) -> None:
+        """list[ndarray] is lazily loaded per-element by default."""
+        from versionable._lazy import LazyArrayList
+
+        traces = [np.array([1.0, 2.0]), np.array([3.0, 4.0, 5.0])]
+        obj = _WithTraces(name="test", traces=traces)
+        p = tmp_path / "lazy_list.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithTraces, p)
+        assert isinstance(loaded.traces, LazyArrayList)
+        assert len(loaded.traces) == 2
+        # Accessing an element loads it
+        np.testing.assert_array_equal(loaded.traces[0], traces[0])
+        np.testing.assert_array_equal(loaded.traces[1], traces[1])
+
+    def test_listNdarrayPreload(self, tmp_path: Path) -> None:
+        """list[ndarray] with preload returns a regular list."""
+        traces = [np.array([1.0, 2.0]), np.array([3.0, 4.0, 5.0])]
+        obj = _WithTraces(name="test", traces=traces)
+        p = tmp_path / "preload_list.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithTraces, p, preload=["traces"])
+        assert isinstance(loaded.traces, list)
+        assert len(loaded.traces) == 2
+        np.testing.assert_array_equal(loaded.traces[0], traces[0])
+
+    def test_listNdarrayMetadataOnly(self, tmp_path: Path) -> None:
+        """list[ndarray] with metadataOnly raises on access."""
+        traces = [np.array([1.0])]
+        obj = _WithTraces(name="test", traces=traces)
+        p = tmp_path / "meta_list.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithTraces, p, metadataOnly=True)
+        assert loaded.name == "test"
+        with pytest.raises(ArrayNotLoadedError):
+            _ = loaded.traces
+
+    def test_dictNdarrayLazy(self, tmp_path: Path) -> None:
+        """dict[str, ndarray] is lazily loaded per-element by default."""
+        from versionable._lazy import LazyArrayDict
+
+        channels = {"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])}
+        obj = _WithChannels(name="test", channels=channels)
+        p = tmp_path / "lazy_dict.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithChannels, p)
+        assert isinstance(loaded.channels, LazyArrayDict)
+        assert len(loaded.channels) == 2
+        assert "ch0" in loaded.channels
+        np.testing.assert_array_equal(loaded.channels["ch0"], channels["ch0"])
+        np.testing.assert_array_equal(loaded.channels["ch1"], channels["ch1"])
+
+    def test_dictNdarrayPreload(self, tmp_path: Path) -> None:
+        """dict[str, ndarray] with preload returns a regular dict."""
+        channels = {"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])}
+        obj = _WithChannels(name="test", channels=channels)
+        p = tmp_path / "preload_dict.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithChannels, p, preload=["channels"])
+        assert isinstance(loaded.channels, dict)
+        np.testing.assert_array_equal(loaded.channels["ch0"], channels["ch0"])
+
+    def test_lazyListIteration(self, tmp_path: Path) -> None:
+        """LazyArrayList supports iteration."""
+        traces = [np.array([float(i)]) for i in range(5)]
+        obj = _WithTraces(name="test", traces=traces)
+        p = tmp_path / "iter_list.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithTraces, p)
+        for i, arr in enumerate(loaded.traces):
+            np.testing.assert_array_equal(arr, traces[i])
+
+    def test_lazyListSlice(self, tmp_path: Path) -> None:
+        """LazyArrayList supports slicing."""
+        traces = [np.array([float(i)]) for i in range(5)]
+        obj = _WithTraces(name="test", traces=traces)
+        p = tmp_path / "slice_list.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithTraces, p)
+        sliced = loaded.traces[1:3]
+        assert len(sliced) == 2
+        np.testing.assert_array_equal(sliced[0], traces[1])
+        np.testing.assert_array_equal(sliced[1], traces[2])
+
+    def test_lazyDictKeys(self, tmp_path: Path) -> None:
+        """LazyArrayDict supports keys(), values(), items()."""
+        channels = {"ch0": np.array([1.0]), "ch1": np.array([2.0])}
+        obj = _WithChannels(name="test", channels=channels)
+        p = tmp_path / "dict_keys.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_WithChannels, p)
+        assert set(loaded.channels.keys()) == {"ch0", "ch1"}
 
 
 def _assertNoJsonAttrs(group: h5py.Group) -> None:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -73,6 +73,25 @@ class _Experiment(Versionable, version=1, hash=_h_experiment, register=False):
     measurements: list[_Measurement]
 
 
+# Deeply nested: Sensor has list[ndarray], Lab has dict[str, Sensor]
+_h_sensor = computeHash({"name": str, "traces": list[npt.NDArray[np.float64]]})
+
+
+@dataclass
+class _Sensor(Versionable, version=1, hash=_h_sensor, name="Sensor"):
+    name: str
+    traces: list[npt.NDArray[np.float64]]
+
+
+_h_lab = computeHash({"title": str, "sensors": dict[str, _Sensor]})
+
+
+@dataclass
+class _Lab(Versionable, version=1, hash=_h_lab, register=False):
+    title: str
+    sensors: dict[str, _Sensor]
+
+
 class TestHdf5RoundTrip:
     def test_simpleScalars(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test", debug=True, retries=5)
@@ -852,35 +871,106 @@ class TestLazyArrayCollections:
         np.testing.assert_array_equal(loaded.data["c"], np.array([2.0]))
         assert len(raw._cache) == 2  # noqa: SLF001
 
-    def test_nestedVersionableEagerArrays(self, tmp_path: Path) -> None:
-        """Nested Versionable groups are eagerly loaded (including their arrays).
+    def test_nestedVersionableLazyArrays(self, tmp_path: Path) -> None:
+        """Arrays inside nested Versionables are lazily loaded."""
+        from versionable._lazy import LazyArray
 
-        Lazy loading currently only applies to top-level array fields and
-        top-level array collection fields. Arrays inside nested Versionable
-        objects are loaded eagerly when the parent group is read.
-        """
         measurements = [
             _Measurement(label="a", data=np.array([1.0, 2.0])),
             _Measurement(label="b", data=np.array([3.0, 4.0, 5.0])),
         ]
         obj = _Experiment(name="exp", measurements=measurements)
-        p = tmp_path / "nested_eager.h5"
+        p = tmp_path / "nested_lazy.h5"
         versionable.save(obj, p)
 
         loaded = versionable.load(_Experiment, p)
 
-        # Scalars are available
+        # Scalars are eagerly available
         assert loaded.name == "exp"
         assert loaded.measurements[0].label == "a"
         assert loaded.measurements[1].label == "b"
 
-        # Arrays inside nested Versionables are eagerly loaded (not lazy)
+        # Arrays inside nested Versionables should be lazy (not loaded yet)
         rawData0 = object.__getattribute__(loaded.measurements[0], "data")
-        assert isinstance(rawData0, np.ndarray), "expected eager ndarray, not LazyArray"
+        assert isinstance(rawData0, LazyArray), f"expected LazyArray, got {type(rawData0).__name__}"
 
-        # Data is correct
+        # Accessing the array triggers lazy load and returns correct data
         np.testing.assert_array_equal(loaded.measurements[0].data, np.array([1.0, 2.0]))
         np.testing.assert_array_equal(loaded.measurements[1].data, np.array([3.0, 4.0, 5.0]))
+
+        # After access, it's cached as ndarray
+        rawData0After = object.__getattribute__(loaded.measurements[0], "data")
+        assert isinstance(rawData0After, np.ndarray)
+
+    def test_nestedVersionablePreloadAll(self, tmp_path: Path) -> None:
+        """preload='*' eagerly loads arrays inside nested Versionables."""
+        measurements = [
+            _Measurement(label="a", data=np.array([1.0, 2.0])),
+        ]
+        obj = _Experiment(name="exp", measurements=measurements)
+        p = tmp_path / "nested_preload.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_Experiment, p, preload="*")
+
+        # With preload="*", arrays should be eagerly loaded
+        rawData0 = object.__getattribute__(loaded.measurements[0], "data")
+        assert isinstance(rawData0, np.ndarray), f"expected ndarray, got {type(rawData0).__name__}"
+        np.testing.assert_array_equal(loaded.measurements[0].data, np.array([1.0, 2.0]))
+
+    def test_deeplyNestedDictVersionableLazy(self, tmp_path: Path) -> None:
+        """dict[str, Versionable] where each Versionable has list[ndarray] — all lazy."""
+        from versionable._lazy import LazyArrayList
+
+        sensors = {
+            "accel": _Sensor(name="accel", traces=[np.array([1.0, 2.0]), np.array([3.0])]),
+            "gyro": _Sensor(name="gyro", traces=[np.array([4.0, 5.0, 6.0])]),
+        }
+        obj = _Lab(title="lab-1", sensors=sensors)
+        p = tmp_path / "deep_lazy.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_Lab, p)
+
+        # Top-level scalar is eager
+        assert loaded.title == "lab-1"
+
+        # dict[str, Versionable] — sensors are eagerly reconstructed (not lazy)
+        assert isinstance(loaded.sensors, dict)
+        assert set(loaded.sensors.keys()) == {"accel", "gyro"}
+
+        # Nested Versionable scalars are eager
+        assert loaded.sensors["accel"].name == "accel"
+        assert loaded.sensors["gyro"].name == "gyro"
+
+        # list[ndarray] inside each nested Versionable should be lazy
+        rawTraces = object.__getattribute__(loaded.sensors["accel"], "traces")
+        assert isinstance(rawTraces, LazyArrayList), f"expected LazyArrayList, got {type(rawTraces).__name__}"
+        assert len(rawTraces._cache) == 0  # noqa: SLF001 — testing lazy internals
+
+        # Accessing individual elements triggers lazy load
+        np.testing.assert_array_equal(loaded.sensors["accel"].traces[0], np.array([1.0, 2.0]))
+        assert len(rawTraces._cache) == 1  # noqa: SLF001
+
+        np.testing.assert_array_equal(loaded.sensors["accel"].traces[1], np.array([3.0]))
+        np.testing.assert_array_equal(loaded.sensors["gyro"].traces[0], np.array([4.0, 5.0, 6.0]))
+
+    def test_deeplyNestedDictVersionablePreload(self, tmp_path: Path) -> None:
+        """dict[str, Versionable] with preload='*' eagerly loads everything."""
+        sensors = {
+            "accel": _Sensor(name="accel", traces=[np.array([1.0, 2.0])]),
+        }
+        obj = _Lab(title="lab-1", sensors=sensors)
+        p = tmp_path / "deep_preload.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_Lab, p, preload="*")
+
+        # With preload="*", traces should be a regular list (not LazyArrayList)
+        assert isinstance(loaded.sensors["accel"].traces, list)
+        rawTraces = object.__getattribute__(loaded.sensors["accel"], "traces")
+        assert isinstance(rawTraces, list), f"expected list, got {type(rawTraces).__name__}"
+        np.testing.assert_array_equal(loaded.sensors["accel"].traces[0], np.array([1.0, 2.0]))
 
 
 def _assertNoJsonAttrs(group: h5py.Group) -> None:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -1,6 +1,6 @@
 # ruff: noqa: E402 — module-level imports must come after pytest.importorskip("h5py")
 # so the entire file is skipped when h5py is not installed.
-"""Tests for the HDF5 backend with lazy loading."""
+"""Tests for the HDF5 backend with native type mapping."""
 
 from __future__ import annotations
 
@@ -8,7 +8,9 @@ import pytest
 
 h5py = pytest.importorskip("h5py")
 
+import datetime
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 import numpy as np
@@ -30,6 +32,27 @@ from versionable.hdf5 import (
 )
 
 from .conftest import Inner, SimpleConfig, WithArray, WithNested
+
+# Module-level classes for tests that need type resolution across nested Versionables.
+# Defining inside test functions causes forward-reference resolution failures with
+# `from __future__ import annotations`.
+
+_h_measurement = computeHash({"label": str, "data": npt.NDArray[np.float64]})
+
+
+@dataclass
+class _Measurement(Versionable, version=1, hash=_h_measurement, name="Measurement"):
+    label: str
+    data: npt.NDArray[np.float64]
+
+
+_h_experiment = computeHash({"name": str, "measurements": list[_Measurement]})
+
+
+@dataclass
+class _Experiment(Versionable, version=1, hash=_h_experiment, register=False):
+    name: str
+    measurements: list[_Measurement]
 
 
 class TestHdf5RoundTrip:
@@ -92,8 +115,9 @@ class TestHdf5Metadata:
         versionable.save(obj, p)
 
         with h5py.File(p, "r") as f:
-            assert f.attrs["__OBJECT__"] == "SimpleConfig"
-            assert f.attrs["__VERSION__"] == 1
+            meta = f["__versionable__"]
+            assert meta.attrs["__OBJECT__"] == "SimpleConfig"
+            assert meta.attrs["__VERSION__"] == 1
 
 
 class TestHdf5Compression:
@@ -256,3 +280,380 @@ class TestHdf5Errors:
     def test_missingFile(self, tmp_path: Path) -> None:
         with pytest.raises(BackendError):
             versionable.load(SimpleConfig, tmp_path / "nonexistent.h5")
+
+
+# ---------------------------------------------------------------------------
+# Native type mapping tests
+# ---------------------------------------------------------------------------
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+class Priority(Enum):
+    LOW = 1
+    HIGH = 2
+
+
+class TestNativeScalars:
+    """Test that scalar fields are stored as native HDF5 attributes."""
+
+    def test_nativeAttributeStorage(self, tmp_path: Path) -> None:
+        """Verify scalars are HDF5 attributes, not JSON blobs."""
+        obj = SimpleConfig(name="test", debug=True, retries=5)
+        p = tmp_path / "native.h5"
+        versionable.save(obj, p)
+
+        with h5py.File(p, "r") as f:
+            # Scalars should be native attributes, not in __scalars__
+            assert "__scalars__" not in f.attrs
+            assert f.attrs["name"] == "test"
+            assert f.attrs["debug"] is np.True_
+            assert f.attrs["retries"] == 5
+
+    def test_floatPrecision(self, tmp_path: Path) -> None:
+        h = computeHash({"value": float})
+
+        @dataclass
+        class FloatData(Versionable, version=1, hash=h, register=False):
+            value: float
+
+        obj = FloatData(value=3.141592653589793)
+        p = tmp_path / "float.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(FloatData, p)
+        assert loaded.value == 3.141592653589793
+        assert isinstance(loaded.value, float)
+
+
+class TestNativeNone:
+    """Test None handling with h5py.Empty."""
+
+    def test_noneField(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "label": str | None})
+
+        @dataclass
+        class WithOptional(Versionable, version=1, hash=h, register=False):
+            name: str
+            label: str | None = None
+
+        obj = WithOptional(name="test", label=None)
+        p = tmp_path / "none.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithOptional, p)
+        assert loaded.name == "test"
+        assert loaded.label is None
+
+    def test_noneVsDefault(self, tmp_path: Path) -> None:
+        """None stored explicitly, not confused with missing default."""
+        h = computeHash({"name": str, "tag": str | None})
+
+        @dataclass
+        class WithDefault(Versionable, version=1, hash=h, register=False):
+            name: str
+            tag: str | None = "default"
+
+        obj = WithDefault(name="test", tag=None)
+        p = tmp_path / "none_vs_default.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithDefault, p)
+        assert loaded.tag is None  # not "default"
+
+
+class TestNativeEnum:
+    """Test Enum storage as native attributes."""
+
+    def test_stringEnum(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "color": Color})
+
+        @dataclass
+        class WithColor(Versionable, version=1, hash=h, register=False):
+            name: str
+            color: Color
+
+        obj = WithColor(name="test", color=Color.GREEN)
+        p = tmp_path / "enum.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithColor, p)
+        assert loaded.color == Color.GREEN
+
+    def test_intEnum(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "priority": Priority})
+
+        @dataclass
+        class WithPriority(Versionable, version=1, hash=h, register=False):
+            name: str
+            priority: Priority
+
+        obj = WithPriority(name="test", priority=Priority.HIGH)
+        p = tmp_path / "int_enum.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithPriority, p)
+        assert loaded.priority == Priority.HIGH
+
+
+class TestNativeConvertedTypes:
+    """Test converted types (datetime, Path) as native attributes."""
+
+    def test_datetime(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "timestamp": datetime.datetime})
+
+        @dataclass
+        class WithDatetime(Versionable, version=1, hash=h, register=False):
+            name: str
+            timestamp: datetime.datetime
+
+        ts = datetime.datetime(2024, 1, 15, 10, 30, 0)
+        obj = WithDatetime(name="test", timestamp=ts)
+        p = tmp_path / "datetime.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithDatetime, p)
+        assert loaded.timestamp == ts
+
+    def test_path(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "location": Path})
+
+        @dataclass
+        class WithPath(Versionable, version=1, hash=h, register=False):
+            name: str
+            location: Path
+
+        obj = WithPath(name="test", location=Path("/tmp/data"))
+        p = tmp_path / "path.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithPath, p)
+        assert loaded.location == Path("/tmp/data")
+
+
+class TestNativeListDatasets:
+    """Test list[numeric], list[str], list[bool] as 1-D datasets."""
+
+    def test_listFloat(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "values": list[float]})
+
+        @dataclass
+        class WithListFloat(Versionable, version=1, hash=h, register=False):
+            name: str
+            values: list[float]
+
+        obj = WithListFloat(name="test", values=[1.0, 2.5, 3.7])
+        p = tmp_path / "list_float.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithListFloat, p)
+        assert loaded.values == [1.0, 2.5, 3.7]
+        assert isinstance(loaded.values, list)
+
+    def test_listInt(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "counts": list[int]})
+
+        @dataclass
+        class WithListInt(Versionable, version=1, hash=h, register=False):
+            name: str
+            counts: list[int]
+
+        obj = WithListInt(name="test", counts=[10, 20, 30])
+        p = tmp_path / "list_int.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithListInt, p)
+        assert loaded.counts == [10, 20, 30]
+
+    def test_listStr(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "tags": list[str]})
+
+        @dataclass
+        class WithListStr(Versionable, version=1, hash=h, register=False):
+            name: str
+            tags: list[str]
+
+        obj = WithListStr(name="test", tags=["alpha", "beta", "gamma"])
+        p = tmp_path / "list_str.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithListStr, p)
+        assert loaded.tags == ["alpha", "beta", "gamma"]
+
+    def test_listBool(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "flags": list[bool]})
+
+        @dataclass
+        class WithListBool(Versionable, version=1, hash=h, register=False):
+            name: str
+            flags: list[bool]
+
+        obj = WithListBool(name="test", flags=[True, False, True])
+        p = tmp_path / "list_bool.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithListBool, p)
+        assert loaded.flags == [True, False, True]
+
+    def test_emptyList(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "values": list[float]})
+
+        @dataclass
+        class WithEmpty(Versionable, version=1, hash=h, register=False):
+            name: str
+            values: list[float]
+
+        obj = WithEmpty(name="test", values=[])
+        p = tmp_path / "empty_list.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithEmpty, p)
+        assert loaded.values == []
+
+
+class TestNativeArrayCollections:
+    """Test list[np.ndarray] and dict[str, np.ndarray] as groups."""
+
+    def test_listNdarray(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "traces": list[npt.NDArray[np.float64]]})
+
+        @dataclass
+        class WithTraces(Versionable, version=1, hash=h, register=False):
+            name: str
+            traces: list[npt.NDArray[np.float64]]
+
+        traces = [np.array([1.0, 2.0]), np.array([3.0, 4.0, 5.0])]
+        obj = WithTraces(name="test", traces=traces)
+        p = tmp_path / "list_ndarray.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithTraces, p, preload="*")
+        assert len(loaded.traces) == 2
+        np.testing.assert_array_equal(loaded.traces[0], traces[0])
+        np.testing.assert_array_equal(loaded.traces[1], traces[1])
+
+    def test_listNdarrayVaryingShapes(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "data": list[npt.NDArray[np.float64]]})
+
+        @dataclass
+        class VaryingShapes(Versionable, version=1, hash=h, register=False):
+            name: str
+            data: list[npt.NDArray[np.float64]]
+
+        arrays = [np.zeros((2, 3)), np.ones((4,)), np.array([[1, 2], [3, 4], [5, 6]])]
+        obj = VaryingShapes(name="test", data=arrays)
+        p = tmp_path / "varying.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(VaryingShapes, p, preload="*")
+        for orig, loaded_arr in zip(arrays, loaded.data, strict=True):
+            np.testing.assert_array_equal(loaded_arr, orig)
+
+    def test_dictNdarray(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "channels": dict[str, npt.NDArray[np.float64]]})
+
+        @dataclass
+        class WithChannels(Versionable, version=1, hash=h, register=False):
+            name: str
+            channels: dict[str, npt.NDArray[np.float64]]
+
+        channels = {"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])}
+        obj = WithChannels(name="test", channels=channels)
+        p = tmp_path / "dict_ndarray.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithChannels, p, preload="*")
+        assert set(loaded.channels.keys()) == {"ch0", "ch1"}
+        np.testing.assert_array_equal(loaded.channels["ch0"], channels["ch0"])
+        np.testing.assert_array_equal(loaded.channels["ch1"], channels["ch1"])
+
+    def test_listNdarrayFileLayout(self, tmp_path: Path) -> None:
+        """Verify list[ndarray] produces integer-keyed datasets in a group."""
+        h = computeHash({"name": str, "traces": list[npt.NDArray[np.float64]]})
+
+        @dataclass
+        class Traces(Versionable, version=1, hash=h, register=False):
+            name: str
+            traces: list[npt.NDArray[np.float64]]
+
+        obj = Traces(name="test", traces=[np.array([1.0]), np.array([2.0])])
+        p = tmp_path / "layout.h5"
+        versionable.save(obj, p)
+
+        with h5py.File(p, "r") as f:
+            assert "traces" in f
+            traces_group = f["traces"]
+            assert isinstance(traces_group, h5py.Group)
+            assert sorted(traces_group.keys()) == ["0", "1"]
+
+
+class TestNativeNestedVersionable:
+    """Test nested Versionable and list[Versionable]."""
+
+    def test_nestedFileLayout(self, tmp_path: Path) -> None:
+        """Verify nested Versionable uses __versionable__ child group."""
+        obj = WithNested(name="origin", point=Inner(x=1.0, y=2.0))
+        p = tmp_path / "nested_layout.h5"
+        versionable.save(obj, p)
+
+        with h5py.File(p, "r") as f:
+            # Root has __versionable__
+            assert "__versionable__" in f
+            # Nested 'point' group has its own __versionable__
+            assert "point" in f
+            point = f["point"]
+            assert isinstance(point, h5py.Group)
+            assert "__versionable__" in point
+            assert point["__versionable__"].attrs["__OBJECT__"] == "Inner"
+
+    def test_listVersionable(self, tmp_path: Path) -> None:
+        h = computeHash({"name": str, "points": list[Inner]})
+
+        @dataclass
+        class WithPointList(Versionable, version=1, hash=h, register=False):
+            name: str
+            points: list[Inner]
+
+        points = [Inner(x=1.0, y=2.0), Inner(x=3.0, y=4.0)]
+        obj = WithPointList(name="test", points=points)
+        p = tmp_path / "list_versionable.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithPointList, p)
+        assert len(loaded.points) == 2
+        assert loaded.points[0].x == 1.0
+        assert loaded.points[0].y == 2.0
+        assert loaded.points[1].x == 3.0
+        assert loaded.points[1].y == 4.0
+
+    def test_nestedWithArrays(self, tmp_path: Path) -> None:
+        """Versionable containing array collections inside nested Versionable."""
+        measurements = [
+            _Measurement(label="a", data=np.array([1.0, 2.0])),
+            _Measurement(label="b", data=np.array([3.0, 4.0, 5.0])),
+        ]
+        obj = _Experiment(name="exp1", measurements=measurements)
+        p = tmp_path / "nested_arrays.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(_Experiment, p, preload="*")
+        assert len(loaded.measurements) == 2
+        assert loaded.measurements[0].label == "a"
+        np.testing.assert_array_equal(loaded.measurements[0].data, np.array([1.0, 2.0]))
+        assert loaded.measurements[1].label == "b"
+        np.testing.assert_array_equal(loaded.measurements[1].data, np.array([3.0, 4.0, 5.0]))
+
+
+class TestNativeNoJson:
+    """Verify that no JSON appears anywhere in the file."""
+
+    def test_noJsonInFile(self, tmp_path: Path) -> None:
+        obj = WithNested(name="test", point=Inner(x=1.0, y=2.0))
+        p = tmp_path / "no_json.h5"
+        versionable.save(obj, p)
+
+        with h5py.File(p, "r") as f:
+            assert "__scalars__" not in f.attrs
+            _assertNoJsonAttrs(f)
+
+
+def _assertNoJsonAttrs(group: h5py.Group) -> None:
+    """Recursively verify no attributes contain JSON strings."""
+    for attrName in group.attrs:
+        value = group.attrs[attrName]
+        if isinstance(value, (str, bytes)):
+            s = value if isinstance(value, str) else value.decode()
+            assert not (s.startswith("{") or s.startswith("[")), (
+                f"Found JSON-like attribute {attrName}={s!r} in {group.name}"
+            )
+    for key in group:
+        item = group[key]
+        if isinstance(item, h5py.Group):
+            _assertNoJsonAttrs(item)

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -822,6 +822,66 @@ class TestLazyArrayCollections:
         loaded = versionable.load(_WithChannels, p)
         assert set(loaded.channels.keys()) == {"ch0", "ch1"}
 
+    def test_lazyDictWithEncodedKeys(self, tmp_path: Path) -> None:
+        """LazyArrayDict decodes percent-encoded keys and loads on access."""
+        from versionable._lazy import LazyArrayDict
+
+        h = computeHash({"data": dict[str, npt.NDArray[np.float64]]})
+
+        @dataclass
+        class WithSlashChannels(Versionable, version=1, hash=h, register=False):
+            data: dict[str, npt.NDArray[np.float64]]
+
+        obj = WithSlashChannels(data={"a/b": np.array([1.0]), "c": np.array([2.0])})
+        p = tmp_path / "lazy_encoded.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(WithSlashChannels, p)
+        raw = object.__getattribute__(loaded, "data")
+        assert isinstance(raw, LazyArrayDict)
+
+        # Keys should be decoded before any data is loaded
+        assert "a/b" in raw
+        assert "c" in raw
+        assert len(raw._cache) == 0  # noqa: SLF001 — testing lazy internals
+
+        # Accessing a key loads only that element
+        np.testing.assert_array_equal(loaded.data["a/b"], np.array([1.0]))
+        assert len(raw._cache) == 1  # noqa: SLF001
+
+        np.testing.assert_array_equal(loaded.data["c"], np.array([2.0]))
+        assert len(raw._cache) == 2  # noqa: SLF001
+
+    def test_nestedVersionableEagerArrays(self, tmp_path: Path) -> None:
+        """Nested Versionable groups are eagerly loaded (including their arrays).
+
+        Lazy loading currently only applies to top-level array fields and
+        top-level array collection fields. Arrays inside nested Versionable
+        objects are loaded eagerly when the parent group is read.
+        """
+        measurements = [
+            _Measurement(label="a", data=np.array([1.0, 2.0])),
+            _Measurement(label="b", data=np.array([3.0, 4.0, 5.0])),
+        ]
+        obj = _Experiment(name="exp", measurements=measurements)
+        p = tmp_path / "nested_eager.h5"
+        versionable.save(obj, p)
+
+        loaded = versionable.load(_Experiment, p)
+
+        # Scalars are available
+        assert loaded.name == "exp"
+        assert loaded.measurements[0].label == "a"
+        assert loaded.measurements[1].label == "b"
+
+        # Arrays inside nested Versionables are eagerly loaded (not lazy)
+        rawData0 = object.__getattribute__(loaded.measurements[0], "data")
+        assert isinstance(rawData0, np.ndarray), "expected eager ndarray, not LazyArray"
+
+        # Data is correct
+        np.testing.assert_array_equal(loaded.measurements[0].data, np.array([1.0, 2.0]))
+        np.testing.assert_array_equal(loaded.measurements[1].data, np.array([3.0, 4.0, 5.0]))
+
 
 def _assertNoJsonAttrs(group: h5py.Group) -> None:
     """Recursively verify no attributes contain JSON strings."""

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -299,6 +299,48 @@ class TestHdf5Errors:
         with pytest.raises(BackendError):
             versionable.load(SimpleConfig, tmp_path / "nonexistent.h5")
 
+    def test_dictKeyWithSlash(self, tmp_path: Path) -> None:
+        """Dict keys containing '/' roundtrip correctly (percent-encoded in HDF5)."""
+        h = computeHash({"data": dict[str, int]})
+
+        @dataclass
+        class WithSlashKey(Versionable, version=1, hash=h, register=False):
+            data: dict[str, int]
+
+        obj = WithSlashKey(data={"valid": 1, "path/key": 2, "a/b/c": 3})
+        p = tmp_path / "slash.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithSlashKey, p)
+        assert loaded.data == {"valid": 1, "path/key": 2, "a/b/c": 3}
+
+    def test_dictKeyWithLiteralPercent(self, tmp_path: Path) -> None:
+        """Dict keys containing literal '%2F' don't collide with escaped '/'."""
+        h = computeHash({"data": dict[str, int]})
+
+        @dataclass
+        class WithPercentKey(Versionable, version=1, hash=h, register=False):
+            data: dict[str, int]
+
+        obj = WithPercentKey(data={"%2F": 1, "/": 2, "normal": 3})
+        p = tmp_path / "percent.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithPercentKey, p)
+        assert loaded.data == {"%2F": 1, "/": 2, "normal": 3}
+
+    def test_dictKeyDot(self, tmp_path: Path) -> None:
+        """Dict key '.' (HDF5 current-group alias) roundtrips correctly."""
+        h = computeHash({"data": dict[str, int]})
+
+        @dataclass
+        class WithDotKey(Versionable, version=1, hash=h, register=False):
+            data: dict[str, int]
+
+        obj = WithDotKey(data={".": 1, "..": 2, ".hidden": 3})
+        p = tmp_path / "dot.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(WithDotKey, p)
+        assert loaded.data == {".": 1, "..": 2, ".hidden": 3}
+
 
 # ---------------------------------------------------------------------------
 # Native type mapping tests
@@ -329,7 +371,7 @@ class TestNativeScalars:
             # Scalars should be native attributes, not in __scalars__
             assert "__scalars__" not in f.attrs
             assert f.attrs["name"] == "test"
-            assert f.attrs["debug"] is np.True_
+            assert bool(f.attrs["debug"]) is True
             assert f.attrs["retries"] == 5
 
     def test_floatPrecision(self, tmp_path: Path) -> None:
@@ -592,6 +634,20 @@ class TestNativeArrayCollections:
             traces_group = f["traces"]
             assert isinstance(traces_group, h5py.Group)
             assert sorted(traces_group.keys()) == ["0", "1"]
+
+    def test_emptyListNdarray(self, tmp_path: Path) -> None:
+        obj = _WithTraces(name="test", traces=[])
+        p = tmp_path / "empty_traces.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(_WithTraces, p, preload="*")
+        assert loaded.traces == []
+
+    def test_emptyDictNdarray(self, tmp_path: Path) -> None:
+        obj = _WithChannels(name="test", channels={})
+        p = tmp_path / "empty_channels.h5"
+        versionable.save(obj, p)
+        loaded = versionable.load(_WithChannels, p, preload="*")
+        assert loaded.channels == {}
 
 
 class TestNativeNestedVersionable:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -531,11 +531,11 @@ class TestNativeConvertedTypes:
             name: str
             location: Path
 
-        obj = WithPath(name="test", location=Path("/tmp/data"))
+        obj = WithPath(name="test", location=Path("/data/results"))
         p = tmp_path / "path.h5"
         versionable.save(obj, p)
         loaded = versionable.load(WithPath, p)
-        assert loaded.location == Path("/tmp/data")
+        assert loaded.location == Path("/data/results")
 
 
 class TestNativeListDatasets:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -318,6 +318,37 @@ class TestHdf5Errors:
         with pytest.raises(BackendError):
             versionable.load(SimpleConfig, tmp_path / "nonexistent.h5")
 
+    def test_unregisteredClassInLoad(self, tmp_path: Path) -> None:
+        """load() raises when the file's __OBJECT__ isn't in the registry."""
+        from versionable._hdf5_backend import Hdf5Backend
+
+        # Write a file with a class name that won't be in the registry
+        p = tmp_path / "unknown.h5"
+        with h5py.File(p, "w") as f:
+            meta = f.create_group("__versionable__")
+            meta.attrs["__OBJECT__"] = "NonexistentClass"
+            meta.attrs["__VERSION__"] = 1
+            meta.attrs["__HASH__"] = "abc123"
+
+        be = Hdf5Backend()
+        with pytest.raises(BackendError, match="Unknown Versionable type"):
+            be.load(p)
+
+    def test_unregisteredClassInLoadLazy(self, tmp_path: Path) -> None:
+        """loadLazy() raises when cls is None and __OBJECT__ isn't registered."""
+        from versionable._hdf5_backend import Hdf5Backend
+
+        p = tmp_path / "unknown_lazy.h5"
+        with h5py.File(p, "w") as f:
+            meta = f.create_group("__versionable__")
+            meta.attrs["__OBJECT__"] = "NonexistentClass"
+            meta.attrs["__VERSION__"] = 1
+            meta.attrs["__HASH__"] = "abc123"
+
+        be = Hdf5Backend()
+        with pytest.raises(BackendError, match="Unknown Versionable type"):
+            be.loadLazy(p)
+
     def test_dictKeyWithSlash(self, tmp_path: Path) -> None:
         """Dict keys containing '/' roundtrip correctly (percent-encoded in HDF5)."""
         h = computeHash({"data": dict[str, int]})

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -115,10 +115,12 @@ class TestJsonMetadata:
         versionable.save(obj, p)
 
         data = json.loads(p.read_text())
-        assert "__OBJECT__" in data
-        assert "__VERSION__" in data
-        assert "__HASH__" in data
-        assert data["__VERSION__"] == 1
+        assert "__versionable__" in data
+        meta = data["__versionable__"]
+        assert "__OBJECT__" in meta
+        assert "__VERSION__" in meta
+        assert "__HASH__" in meta
+        assert meta["__VERSION__"] == 1
 
     def test_prettyPrinted(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test")
@@ -166,9 +168,11 @@ class TestUnknownFields:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "SimpleConfig",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "name": "test",
                     "debug": False,
                     "retries": 3,
@@ -193,9 +197,11 @@ class TestJsonLiteral:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "WithLiteral",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "WithLiteral",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "name": "test",
                     "mode": "banana",
                 }
@@ -209,9 +215,11 @@ class TestJsonLiteral:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "WithLiteral",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "WithLiteral",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "name": "test",
                     "mode": "banana",
                 }
@@ -264,9 +272,11 @@ class TestErrors:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "SimpleConfig",
-                    "__VERSION__": 999,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 999,
+                        "__HASH__": "",
+                    },
                     "name": "test",
                 }
             )

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -181,9 +181,11 @@ class TestEndToEndMigration:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "MigConfig",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "MigConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "name": "old-config",
                 }
             )
@@ -207,9 +209,11 @@ class TestEndToEndMigration:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "MigDoc",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "MigDoc",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "title": "My Document",
                 }
             )
@@ -234,9 +238,11 @@ class TestEndToEndMigration:
         p.write_text(
             json.dumps(
                 {
-                    "__OBJECT__": "MigApp",
-                    "__VERSION__": 1,
-                    "__HASH__": "",
+                    "__versionable__": {
+                        "__OBJECT__": "MigApp",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                    },
                     "title": "Old App",
                 }
             )
@@ -283,7 +289,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'title = "batch-processor"\ndebug = false\nretries = 5\n\n'
-            '[__meta__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 1\n__HASH__ = "5556c8"\n',
+            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 1\n__HASH__ = "5556c8"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 0.0
@@ -294,7 +300,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'name = "batch-processor"\ndebug = false\nretries = 5\n\n'
-            '[__meta__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 2\n__HASH__ = "ed3a90"\n',
+            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 2\n__HASH__ = "ed3a90"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 0.0
@@ -305,7 +311,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'name = "batch-processor"\nretries = 5\ntimeout_s = 7.5\n\n'
-            '[__meta__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 3\n__HASH__ = "ea7fc2"\n',
+            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 3\n__HASH__ = "ea7fc2"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 7.5

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -101,9 +101,9 @@ class TestTomlMetadata:
         versionable.save(obj, p)
 
         data = toml.loads(p.read_text())
-        assert "__meta__" in data
-        assert data["__meta__"]["__OBJECT__"] == "SimpleConfig"
-        assert data["__meta__"]["__VERSION__"] == 1
+        assert "__versionable__" in data
+        assert data["__versionable__"]["__OBJECT__"] == "SimpleConfig"
+        assert data["__versionable__"]["__VERSION__"] == 1
 
     def test_nestedUsesNativeTable(self, tmp_path: Path) -> None:
         """Nested Versionable should use TOML table syntax, not JSON wrapper."""
@@ -149,9 +149,9 @@ class TestTomlCommentDefaults:
         # "debug" and "retries" are at defaults — should be commented
         assert "# debug = false" in text
         assert "# retries = 3" in text
-        # __meta__ should NOT be commented
-        assert "[__meta__]" in text
-        assert "# [__meta__]" not in text
+        # __versionable__ should NOT be commented
+        assert "[__versionable__]" in text
+        assert "# [__versionable__]" not in text
 
     def test_nonDefaultsNotCommented(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test", debug=True, retries=10)
@@ -190,7 +190,7 @@ class TestTomlLiteral:
         p.write_text(
             toml.dumps(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -206,7 +206,7 @@ class TestTomlLiteral:
         p.write_text(
             toml.dumps(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -218,7 +218,7 @@ class TestTomlLiteral:
 
 class TestTomlMissingVersion:
     def test_noVersionDefaultsToCurrentVersion(self, tmp_path: Path) -> None:
-        """A TOML file with no __meta__ should load as the current version."""
+        """A TOML file with no __versionable__ should load as the current version."""
         p = tmp_path / "plain.toml"
         p.write_text('name = "test"\ndebug = true\nretries = 5\n')
         loaded = versionable.load(SimpleConfig, p)
@@ -227,7 +227,7 @@ class TestTomlMissingVersion:
         assert loaded.retries == 5
 
     def test_noVersionLogsWarning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """A TOML file with no __meta__ should log a warning."""
+        """A TOML file with no __versionable__ should log a warning."""
         p = tmp_path / "plain.toml"
         p.write_text('name = "test"\ndebug = false\nretries = 3\n')
         with caplog.at_level("WARNING"):

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -125,8 +125,8 @@ class TestYamlMetadata:
         versionable.save(obj, p)
 
         data = yaml.safe_load(p.read_text())
-        assert "__meta__" in data
-        meta = data["__meta__"]
+        assert "__versionable__" in data
+        meta = data["__versionable__"]
         assert meta["__OBJECT__"] == "SimpleConfig"
         assert meta["__VERSION__"] == 1
         assert "__HASH__" in meta
@@ -174,9 +174,9 @@ class TestYamlCommentDefaults:
         # "debug" and "retries" are at defaults — should be commented
         assert "# debug:" in text
         assert "# retries:" in text
-        # __meta__ should NOT be commented
-        assert "\n__meta__:\n" in text or text.startswith("__meta__:\n")
-        assert "# __meta__:" not in text
+        # __versionable__ should NOT be commented
+        assert "\n__versionable__:\n" in text or text.startswith("__versionable__:\n")
+        assert "# __versionable__:" not in text
 
     def test_nonDefaultsNotCommented(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test", debug=True, retries=10)
@@ -215,7 +215,7 @@ class TestYamlCommentDefaults:
 
 class TestYamlMissingVersion:
     def test_noMetaDefaultsToCurrentVersion(self, tmp_path: Path) -> None:
-        """A file with no __meta__ should load as the current version (no migrations)."""
+        """A file with no __versionable__ should load as the current version (no migrations)."""
         p = tmp_path / "plain.yaml"
         p.write_text("name: test\ndebug: true\nretries: 5\n")
         loaded = versionable.load(SimpleConfig, p)
@@ -224,7 +224,7 @@ class TestYamlMissingVersion:
         assert loaded.retries == 5
 
     def test_noMetaLogsWarning(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """A file with no __meta__ should log a warning."""
+        """A file with no __versionable__ should log a warning."""
         p = tmp_path / "plain.yaml"
         p.write_text("name: test\ndebug: false\nretries: 3\n")
         with caplog.at_level("WARNING"):
@@ -255,7 +255,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -269,7 +269,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -283,7 +283,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteralNoValidation", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteralNoValidation", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -298,7 +298,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {"__OBJECT__": "WithLiteralFallback", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"__OBJECT__": "WithLiteralFallback", "__VERSION__": 1, "__HASH__": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -329,7 +329,7 @@ class TestYamlErrors:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {
+                    "__versionable__": {
                         "__OBJECT__": "SimpleConfig",
                         "__VERSION__": 1,
                         "__HASH__": "",
@@ -351,7 +351,7 @@ class TestYamlErrors:
         p.write_text(
             yaml.dump(
                 {
-                    "__meta__": {
+                    "__versionable__": {
                         "__OBJECT__": "SimpleConfig",
                         "__VERSION__": 999,
                         "__HASH__": "",


### PR DESCRIPTION
## Summary

Every field now maps to a native HDF5 construct instead of being stuffed into a JSON blob. Files are readable with h5dump, HDFView, MATLAB, or any HDF5-compatible tool.

## Changes

- Refactor `Backend.save()` to accept `cls` and raw values — each backend owns serialization
- Native type mapping: scalars → attributes, arrays → datasets, lists/dicts → groups, nested Versionable → subgroups with `__versionable__` metadata
- `h5py.Empty` for None, per-element lazy loading for `list[np.ndarray]` and `dict[str, np.ndarray]`
- Cross-backend roundtrip tests (92 tests) covering all types across JSON/YAML/TOML/HDF5
- Documentation updates for backends, types, reference, and AGENT

## Tests performed

- 327 tests passing (121 new)
- Kitchen sink roundtrip with exact type verification across all 4 backends
- 13 numpy dtypes × 4 backends
- Lazy loading, preload, metadataOnly for array collections