### PR TITLE
Add FAQ, contributing guide, and rewrite hash/background sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ versionable uses [Pixi](https://pixi.sh) for environment management:
 pixi install
 ```
 
-This installs all dependencies, including optional backends (TOML, YAML, HDF5) and dev tools (pytest, mypy, ruff).
-When you're ready, open a PR from your fork against `main`.
+This installs all dependencies, including optional backends (TOML, YAML, HDF5) and dev tools (pytest, mypy, ruff). When
+you're ready, open a PR from your fork against `main`.
 
 ## Running Checks
 
@@ -30,8 +30,8 @@ pixi run cleanup          # formatters, linters, type checkers
 pixi run test             # pytest
 ```
 
-`cleanup` runs ruff (format + lint), mypy, pyright, prettier (markdown), and markdownlint. Fix all errors before
-pushing — CI runs the same checks.
+`cleanup` runs ruff (format + lint), mypy, pyright, prettier (markdown), and markdownlint. Fix all errors before pushing
+— CI runs the same checks.
 
 To run checks individually:
 
@@ -75,13 +75,13 @@ This project uses **camelCase** for functions, methods, and variables — see th
 [FAQ](https://versionable.readthedocs.io/faq.html#why-camelcase-instead-of-snake-case) for why. Test files use
 `snake_case` (pytest convention).
 
-| What | Style | Example |
-| --- | --- | --- |
-| Functions / methods / variables | `camelCase` | `computeHash()`, `fieldType` |
-| Classes / types | `PascalCase` | `Versionable`, `JsonBackend` |
-| Constants | `SCREAMING_SNAKE_CASE` | `_CANONICAL_NAMES` |
-| Private members | Leading underscore | `_registry`, `_resolveFields()` |
-| Test functions | `snake_case` with `test_` prefix | `test_roundtrip()` |
+| What                            | Style                            | Example                         |
+| ------------------------------- | -------------------------------- | ------------------------------- |
+| Functions / methods / variables | `camelCase`                      | `computeHash()`, `fieldType`    |
+| Classes / types                 | `PascalCase`                     | `Versionable`, `JsonBackend`    |
+| Constants                       | `SCREAMING_SNAKE_CASE`           | `_CANONICAL_NAMES`              |
+| Private members                 | Leading underscore               | `_registry`, `_resolveFields()` |
+| Test functions                  | `snake_case` with `test_` prefix | `test_roundtrip()`              |
 
 ### Type Annotations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to versionable
+
+Thanks for your interest in contributing! This document covers how to set up the project, run checks, and submit
+changes.
+
+## Getting Started
+
+External contributions should come from a **fork**. Fork the repo on GitHub, then clone your fork:
+
+```bash
+git clone https://github.com/<your-username>/versionable.git
+cd versionable
+```
+
+versionable uses [Pixi](https://pixi.sh) for environment management:
+
+```bash
+pixi install
+```
+
+This installs all dependencies, including optional backends (TOML, YAML, HDF5) and dev tools (pytest, mypy, ruff).
+When you're ready, open a PR from your fork against `main`.
+
+## Running Checks
+
+Before submitting a PR, run the full cleanup and test suite:
+
+```bash
+pixi run cleanup          # formatters, linters, type checkers
+pixi run test             # pytest
+```
+
+`cleanup` runs ruff (format + lint), mypy, pyright, prettier (markdown), and markdownlint. Fix all errors before
+pushing — CI runs the same checks.
+
+To run checks individually:
+
+```bash
+pixi run format           # ruff format
+pixi run ruff             # ruff check --fix
+pixi run mypy             # mypy src/
+pixi run pyright          # pyright src/
+pixi run test             # pytest
+```
+
+## CI Environments
+
+CI runs in two environments:
+
+- **default** — all backends installed (JSON, TOML, YAML, HDF5)
+- **minimal** — JSON backend only (no h5py, pyyaml, or toml)
+
+You can run both locally:
+
+```bash
+pixi run ci-all
+```
+
+## Building Documentation
+
+Documentation uses Sphinx with MyST markdown and lives in the `docs/` directory. It builds in its own pixi environment:
+
+```bash
+pixi run -e docs docs             # one-time build → docs/_build/html/
+pixi run -e docs docs-live        # live-reload server for local editing
+```
+
+CI also builds the docs on every PR, so you'll see a failure if your changes break the build.
+
+## Code Style
+
+### Naming Conventions
+
+This project uses **camelCase** for functions, methods, and variables — see the
+[FAQ](https://versionable.readthedocs.io/faq.html#why-camelcase-instead-of-snake-case) for why. Test files use
+`snake_case` (pytest convention).
+
+| What | Style | Example |
+| --- | --- | --- |
+| Functions / methods / variables | `camelCase` | `computeHash()`, `fieldType` |
+| Classes / types | `PascalCase` | `Versionable`, `JsonBackend` |
+| Constants | `SCREAMING_SNAKE_CASE` | `_CANONICAL_NAMES` |
+| Private members | Leading underscore | `_registry`, `_resolveFields()` |
+| Test functions | `snake_case` with `test_` prefix | `test_roundtrip()` |
+
+### Type Annotations
+
+All functions and instance variables must have type hints. Use modern syntax (`X | Y`, `list[T]`, `dict[K, V]`). Avoid
+`Any` unless strictly necessary — add a short comment explaining why if you do.
+
+Never use `# type: ignore`, `# noqa:`, or pyright `exclude` to suppress type errors. Fix the underlying issue instead.
+
+### Imports
+
+```python
+from __future__ import annotations
+
+# 1. Standard library
+import hashlib
+from typing import Any
+
+# 2. Third-party
+import numpy as np
+
+# 3. Local
+from versionable._hash import computeHash
+```
+
+### Tests
+
+- Tests live in `tests/` and use pytest
+- Test file names match `test_*.py`
+- Use `snake_case` for all identifiers in test files
+- Hardcode schema hashes as string literals (e.g., `hash="74a182"`) — don't call `computeHash()` in tests
+
+## Pull Requests
+
+- Open PRs from your fork
+- Target the `main` branch
+- Preserve individual commit history — we don't squash merge
+- Keep PR descriptions concise: what changed, why, and what you tested
+
+### PR Description Format
+
+```text
+**Description:** Brief explanation of what and why
+
+**Changes:**
+- Bullet point of change 1
+- Bullet point of change 2
+
+**Tests performed:**
+- Test scenario 1
+- Test scenario 2
+```
+
+## Project Structure
+
+```text
+src/versionable/       Source code (src layout)
+  __init__.py          Public API exports
+  _api.py              save() / load() entry points
+  _base.py             Versionable mixin, registry, metadata
+  _hash.py             Schema hash computation
+  _types.py            Type converter registry + built-in converters
+  _migration.py        Declarative and imperative migrations
+  _backend.py          Backend abstract base class
+  _json_backend.py     JSON backend
+  _toml_backend.py     TOML backend (optional)
+  _yaml_backend.py     YAML backend (optional)
+  _hdf5_backend.py     HDF5 backend (optional)
+  _hdf5_session.py     Incremental HDF5 sessions
+  errors.py            Exception hierarchy
+tests/                 pytest test suite
+docs/                  Sphinx documentation (MyST markdown)
+```
+
+Private modules (prefixed with `_`) are internal — public API is exposed only through `__init__.py`.
+
+## Reporting Issues
+
+File issues on [GitHub](https://github.com/hendrickmelo/versionable/issues). Include:
+
+- What you expected vs. what happened
+- A minimal reproducible example
+- Python version and versionable version (`python -c "import versionable; print(versionable.__version__)"`)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ formats.
 Your data lives in files. Your code keeps changing. Without versioning, old files silently load with missing fields,
 wrong types, or stale values.
 
-**`versionable`** fixes that.  Like database migrations, but for files. Every file is stamped with a version number and a
+**`versionable`** fixes that. Like database migrations, but for files. Every file is stamped with a version number and a
 fingerprint of its structure. Files written by v1 of your code load cleanly into v5, automatically migrated, never
 silently broken. Save to standard formats out of the box: JSON, HDF5, YAML, and TOML.
 
@@ -117,7 +117,7 @@ The `hash` parameter is optional — everything works without it. But when prese
 Without it, here's what happens: you rename a field, forget to add a migration, and old files load with a missing field
 that silently defaults to zero. Your experiment runs with wrong calibration data for a week before anyone notices.
 
-The hash prevents that. It's a fingerprint of your fields and their types, validated at *import time* — not at runtime,
+The hash prevents that. It's a fingerprint of your fields and their types, validated at _import time_ — not at runtime,
 not in production. Change a field and forget to update the version? Python won't even import:
 
 ```python
@@ -182,8 +182,8 @@ For custom type converters, HDF5 support, and more, see the
 
 The pattern behind **`versionable`** has been used in production C++ systems for over 15 years — from `CArchive`-based
 serialization to modern C++11 variadic macros. Some version of this pattern has been a part of every project the authors
-have worked on. This is our second Python implementation of a proven approach, built with modern type-safe Python. The test
-suite has a ~1:1 ratio of test code to source code, with cross-backend round-trip coverage and edge-case validation
+have worked on. This is our second Python implementation of a proven approach, built with modern type-safe Python. The
+test suite has a ~1:1 ratio of test code to source code, with cross-backend round-trip coverage and edge-case validation
 across all four backends.
 
 Have questions? See the **[FAQ](docs/faq.md)**. Want to contribute? See the **[contributing guide](CONTRIBUTING.md)**.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ formats.
 Your data lives in files. Your code keeps changing. Without versioning, old files silently load with missing fields,
 wrong types, or stale values.
 
-**`versionable`** fixes that. Every file is stamped with a version number and a fingerprint of its structure. Files
-written by v1 of your code load cleanly into v5, automatically migrated, never silently broken. Save to standard formats
-out of the box: JSON, HDF5, YAML, and TOML.
+**`versionable`** fixes that.  Like database migrations, but for files. Every file is stamped with a version number and a
+fingerprint of its structure. Files written by v1 of your code load cleanly into v5, automatically migrated, never
+silently broken. Save to standard formats out of the box: JSON, HDF5, YAML, and TOML.
 
 **What you get:**
 
@@ -110,27 +110,29 @@ loaded = versionable.load(SensorConfig, "config.yaml")
 assert loaded.magnitude == 9.81
 ```
 
-### Catching Version Drift
+### The Schema Hash — Friction as a Feature
 
-The `hash` parameter is a fingerprint of your fields and their types. It's optional, but when present it catches version
-drift: if you change a field and forget to bump the version, Python raises an error as soon as the module is imported.
-Not when a user opens a corrupt file in production. During development, in CI, at deploy time.
+The `hash` parameter is optional — everything works without it. But when present, it acts as a tripwire.
 
-For example, if you rename `value` to `magnitude` but keep the old hash:
+Without it, here's what happens: you rename a field, forget to add a migration, and old files load with a missing field
+that silently defaults to zero. Your experiment runs with wrong calibration data for a week before anyone notices.
+
+The hash prevents that. It's a fingerprint of your fields and their types, validated at *import time* — not at runtime,
+not in production. Change a field and forget to update the version? Python won't even import:
 
 ```python
-# This raises at import time — not at runtime, not in production
 @dataclass
-class SensorConfig(Versionable, version=2, hash="4b7866"):  # ⬅ Old V1 Hash
+class SensorConfig(Versionable, version=2, hash="4b7866"):  # ⬅ old hash
     name: str
     magnitude: float  # changed, but hash wasn't updated
-    ...
 
 # HashMismatchError: SensorConfig: hash mismatch — declared '4b7866',
 #   computed 'a70249'. Update the hash parameter to 'a70249'.
 ```
 
-Update the hash, add a migration, and you're done ✔️. A few weird looking characters now, and your data is future-proof.
+That error is the point. It means you can't accidentally ship a schema change without a migration. The hash makes
+breaking changes visible during development, in CI, at deploy time — never in production. Think of it like a type
+checker for your data format: optional, zero runtime cost, catches mistakes before they matter.
 
 ### Working with Large Data
 
@@ -176,15 +178,21 @@ If you're an AI agent working with versionable, see **[AGENT.md](docs/AGENT.md)*
 For custom type converters, HDF5 support, and more, see the
 **[full documentation](https://versionable.readthedocs.io)**.
 
+## Background
+
+The pattern behind **`versionable`** has been used in production C++ systems for over 15 years — from `CArchive`-based
+serialization to modern C++11 variadic macros. Some version of this pattern has been a part of every project the authors
+have worked on. This is our second Python implementation of a proven approach, built with modern type-safe Python. The test
+suite has a ~1:1 ratio of test code to source code, with cross-backend round-trip coverage and edge-case validation
+across all four backends.
+
+Have questions? See the **[FAQ](docs/faq.md)**. Want to contribute? See the **[contributing guide](CONTRIBUTING.md)**.
+
 ## Acknowledgements
 
-The idea behind versionable started over 15 years ago in C++, where I first learned the approach from
-[Steve Araiza](https://github.com/saraiza). Over the years the idea of a Serializable / Versionable class evolved from
-using `CArchive` to make use of C++11, variadic macros, and other fun modern C++ features. Some version of this pattern
-has been a part of every project I've worked on since those days.
-
-This is the Python version of the idea. It is built using modern, type-safe Python with great fresh ideas from
-[Emma Powers](https://github.com/emmapowers/).
+The idea started with [Steve Araiza](https://github.com/saraiza), who first taught me this approach. Over the years it
+evolved through many C++ iterations, and every project I've worked on since has used some version of this pattern.
+[Emma Powers](https://github.com/emmapowers/) brought great fresh ideas to this Python implementation.
 
 A big thank you to both of them! 🥓🥞🍳
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../CONTRIBUTING.md
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 # Contributing
 
 ```{include} ../CONTRIBUTING.md
-
+:start-after: "# Contributing to versionable"
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,2 +1,5 @@
+# Contributing
+
 ```{include} ../CONTRIBUTING.md
+
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,10 +2,10 @@
 
 ## Is this production-ready?
 
-Version 0.1.0 reflects a new *release*, not a new *idea*. The versioned-serialization pattern behind versionable has
-been used in production C++ systems for over 15 years. From `CArchive`-based serialization through C++11 variadic
-macros and modern template metaprogramming. Some version of this pattern has shipped in every project the authors have
-worked on.
+Version 0.1.0 reflects a new _release_, not a new _idea_. The versioned-serialization pattern behind versionable has
+been used in production C++ systems for over 15 years. From `CArchive`-based serialization through C++11 variadic macros
+and modern template metaprogramming. Some version of this pattern has shipped in every project the authors have worked
+on.
 
 This Python implementation is new, but the design decisions are informed by hard-won experience:
 
@@ -36,13 +36,13 @@ class Config(Versionable, version=1):
 Without a hash, versionable still handles versioning, migrations, and serialization. You just won't get import-time
 validation when your schema changes.
 
-The hash exists to create *intentional friction*. When you change a field — rename it, change its type, add or remove
+The hash exists to create _intentional friction_. When you change a field — rename it, change its type, add or remove
 one — the hash forces you to acknowledge the change. You can't accidentally ship a schema change without writing a
 migration. That friction is the feature: it moves data-format breakage from "silent corruption in production" to "error
 during development."
 
-Think of it like a type annotation or a lockfile hash: optional, zero runtime cost, catches mistakes before they
-matter. If you're familiar with database migrations, it's the same idea — you'd never alter a production table without a
+Think of it like a type annotation or a lockfile hash: optional, zero runtime cost, catches mistakes before they matter.
+If you're familiar with database migrations, it's the same idea — you'd never alter a production table without a
 migration script. The hash enforces that same discipline for your data files. We recommend using it for any class whose
 data files outlive a single session.
 
@@ -55,8 +55,8 @@ workflows (JSON, TOML, YAML with scalars and strings) should have zero heavy dep
 
 ## Can I use this with Python 3.11 or earlier?
 
-Not currently. Versionable requires Python 3.12+ and uses modern syntax features like the `type` statement and
-`list[T]` / `dict[K, V]` built-in generics. There are no plans to backport to earlier Python versions.
+Not currently. Versionable requires Python 3.12+ and uses modern syntax features like the `type` statement and `list[T]`
+/ `dict[K, V]` built-in generics. There are no plans to backport to earlier Python versions.
 
 ## What happens if I load a file written by a newer version of my class?
 
@@ -67,8 +67,9 @@ This is intentional — automatic downgrades risk data loss.
 
 However, not every change requires a version bump. If you're adding a new field with a default value and it doesn't
 affect older versions of your software, you can add the field without bumping the version — just update the hash. Older
-files will load fine because the missing field falls back to its default. This way, you only break forwards compatibility when it's on purpose: a version bump means "older code can't read
-these files," and the absence of one means "this change is safe to ignore."
+files will load fine because the missing field falls back to its default. This way, you only break forwards
+compatibility when it's on purpose: a version bump means "older code can't read these files," and the absence of one
+means "this change is safe to ignore."
 
 Forwards incompatibility is the trade-off you make for simple migration code. Migrations only need to go in one
 direction, which keeps them straightforward and composable. In practice, upgrading readers is far easier than
@@ -78,7 +79,7 @@ maintaining bidirectional migrations.
 
 Pydantic and attrs are validation and data-modeling libraries. They answer "is this data shaped correctly right now?"
 
-Versionable answers a different question: "this data was shaped correctly *when it was written* — how do I load it now
+Versionable answers a different question: "this data was shaped correctly _when it was written_ — how do I load it now
 that the code has changed?" It adds versioning, schema fingerprinting, and declarative migrations on top of standard
 Python dataclasses. The two concerns are complementary — you could use Pydantic for API validation and versionable for
 file persistence in the same project.
@@ -96,7 +97,6 @@ years ago, and the naming conventions carried forward intentionally. The Python 
 been implemented in.
 
 We're aware this goes against PEP 8 convention for functions and variables. In practice, libraries like `unittest`
-(`assertEqual`, `setUp`), `logging` (`getLogger`, `setLevel`), and Qt bindings (`paintEvent`, `setLayout`) use
-camelCase throughout their public APIs and it hasn't blocked adoption. We chose consistency with the pattern's history
-over convention conformance.
-
+(`assertEqual`, `setUp`), `logging` (`getLogger`, `setLevel`), and Qt bindings (`paintEvent`, `setLayout`) use camelCase
+throughout their public APIs and it hasn't blocked adoption. We chose consistency with the pattern's history over
+convention conformance.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,102 @@
+# FAQ
+
+## Is this production-ready?
+
+Version 0.1.0 reflects a new *release*, not a new *idea*. The versioned-serialization pattern behind versionable has
+been used in production C++ systems for over 15 years. From `CArchive`-based serialization through C++11 variadic
+macros and modern template metaprogramming. Some version of this pattern has shipped in every project the authors have
+worked on.
+
+This Python implementation is new, but the design decisions are informed by hard-won experience:
+
+- **Hash validated at class definition time** — catches schema drift at import, not at runtime. This is a deliberate
+  architectural choice, not a shortcut.
+- **`__init_subclass__`, not metaclass** — avoids metaclass conflicts and keeps inheritance simple.
+- **Serialization names, not module paths** — hashes are stable across file moves and refactors.
+- **Backends own their serialization** — each backend maps types to its native format (HDF5 uses datasets, not JSON
+  inside HDF5). No lowest-common-denominator intermediate representation.
+
+The test suite has a ~1:1 ratio of test code to source code (~4,400 lines of tests for ~4,500 lines of source), with
+cross-backend round-trip coverage, migration chaining, HDF5 dtype preservation, lazy loading, and edge cases for union
+types, enums, and nested versioned objects.
+
+We use semver. The API is stable for documented use cases. Breaking changes will bump the minor version until 1.0.
+
+## Is the schema hash required?
+
+No. The hash parameter is entirely optional. This works fine:
+
+```python
+@dataclass
+class Config(Versionable, version=1):
+    name: str
+    debug: bool = False
+```
+
+Without a hash, versionable still handles versioning, migrations, and serialization. You just won't get import-time
+validation when your schema changes.
+
+The hash exists to create *intentional friction*. When you change a field — rename it, change its type, add or remove
+one — the hash forces you to acknowledge the change. You can't accidentally ship a schema change without writing a
+migration. That friction is the feature: it moves data-format breakage from "silent corruption in production" to "error
+during development."
+
+Think of it like a type annotation or a lockfile hash: optional, zero runtime cost, catches mistakes before they
+matter. If you're familiar with database migrations, it's the same idea — you'd never alter a production table without a
+migration script. The hash enforces that same discipline for your data files. We recommend using it for any class whose
+data files outlive a single session.
+
+## Why does the base install require numpy?
+
+It shouldn't — this is a known issue ([#17](https://github.com/hendrickmelo/versionable/issues/17)). A future release
+will make numpy optional, required only when using ndarray fields or the HDF5 backend. The base install for config-only
+workflows (JSON, TOML, YAML with scalars and strings) should have zero heavy dependencies. If this matters to you,
+**please upvote the issue** — it helps us prioritize.
+
+## Can I use this with Python 3.11 or earlier?
+
+Not currently. Versionable requires Python 3.12+ and uses modern syntax features like the `type` statement and
+`list[T]` / `dict[K, V]` built-in generics. There are no plans to backport to earlier Python versions.
+
+## What happens if I load a file written by a newer version of my class?
+
+You get a `VersionError`. Versionable supports forward migrations (old file → current code) but not downgrades. If your
+file was written by version 5 of a class and your code defines version 3, loading will fail with a clear error message.
+
+This is intentional — automatic downgrades risk data loss.
+
+However, not every change requires a version bump. If you're adding a new field with a default value and it doesn't
+affect older versions of your software, you can add the field without bumping the version — just update the hash. Older
+files will load fine because the missing field falls back to its default. This way, you only break forwards compatibility when it's on purpose: a version bump means "older code can't read
+these files," and the absence of one means "this change is safe to ignore."
+
+Forwards incompatibility is the trade-off you make for simple migration code. Migrations only need to go in one
+direction, which keeps them straightforward and composable. In practice, upgrading readers is far easier than
+maintaining bidirectional migrations.
+
+## How is versionable different from Pydantic or attrs?
+
+Pydantic and attrs are validation and data-modeling libraries. They answer "is this data shaped correctly right now?"
+
+Versionable answers a different question: "this data was shaped correctly *when it was written* — how do I load it now
+that the code has changed?" It adds versioning, schema fingerprinting, and declarative migrations on top of standard
+Python dataclasses. The two concerns are complementary — you could use Pydantic for API validation and versionable for
+file persistence in the same project.
+
+## Can I use my own file format?
+
+Yes. Implement the `Backend` abstract class with `save()` and `load()` methods, then register it with
+`registerBackend()`. See the [backends documentation](backends.md) for details.
+
+## Why camelCase instead of snake_case?
+
+This is a deliberate convention, not an oversight. The `Versionable` / `Serializable` pattern originated in C++ over 15
+years ago, and the naming conventions carried forward intentionally. The Python implementation uses the same vocabulary
+(`computeHash`, `registerConverter`, `skipDefaults`) that the authors have used across every language this pattern has
+been implemented in.
+
+We're aware this goes against PEP 8 convention for functions and variables. In practice, libraries like `unittest`
+(`assertEqual`, `setUp`), `logging` (`getLogger`, `setLevel`), and Qt bindings (`paintEvent`, `setLayout`) use
+camelCase throughout their public APIs and it hasn't blocked adoption. We chose consistency with the pattern's history
+over convention conformance.
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,8 +55,10 @@ workflows (JSON, TOML, YAML with scalars and strings) should have zero heavy dep
 
 ## Can I use this with Python 3.11 or earlier?
 
-Not currently. Versionable requires Python 3.12+ and uses modern syntax features like the `type` statement and `list[T]`
-/ `dict[K, V]` built-in generics. There are no plans to backport to earlier Python versions.
+Not currently. Versionable requires Python 3.12+ because it uses [PEP 695](https://peps.python.org/pep-0695/) syntax
+throughout — `type` aliases (`type MigrationOp = ...`) and generic type parameters on classes and functions
+(`class Hdf5Session[T: Versionable]`, `def load[T: Versionable](...)`). There are no plans to backport to earlier Python
+versions.
 
 ## What happens if I load a file written by a newer version of my class?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,12 @@ migrations
 backends
 types
 reference
+faq
+contributing
 ai-agents
 ```
 
 ```{include} ../README.md
 :start-after: "**[full documentation](https://versionable.readthedocs.io)**."
+:end-before: "## Background"
 ```


### PR DESCRIPTION
**Description:** Commit was on feature/v0.1.0-prep but missed the merge to main.

**Changes:**
- New FAQ page (docs/faq.md)
- New contributing guide (CONTRIBUTING.md + docs/contributing.md)
- Rewritten README hash/background sections
- Updated docs/index.md toctree