### PR TITLE
Bump version to 0.1.1.dev1

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6651,8 +6651,8 @@ packages:
   timestamp: 1767320173250
 - pypi: ./
   name: versionable
-  version: 0.1.1.dev0
-  sha256: f0be20ac7043fdef15ca812721d637fa74d018fcbc69b870380b4659bcaba77c
+  version: 0.1.1.dev1
+  sha256: 86f37afa7a162985021a87d289d6b0234f0979c25ec65cb8f8e4e321ccb55679
   requires_dist:
   - numpy>=1.26
   - toml>=0.10 ; extra == 'toml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "versionable"
-version = "0.1.1.dev0"
+version = "0.1.1.dev1"
 description = "Versioned persistence for Python dataclasses with hash validation, declarative migrations, and pluggable backends"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump dev version from `0.1.1.dev0` to `0.1.1.dev1` in `pyproject.toml`
- Update `pixi.lock` to reflect the new version

## Testing

- `pixi install --locked` succeeds with updated lock file
- `pixi run cleanup` passes