### PR TITLE
Make numpy an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ silently broken. Save to standard formats out of the box: JSON, HDF5, YAML, and 
 
 ## Installation
 
-The base install includes the JSON backend (no extra dependencies beyond numpy):
+The base install includes the JSON backend with zero heavy dependencies:
 
 ```bash
 pip install versionable

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -6,7 +6,7 @@ type converters, and pluggable storage backends.
 ## Installation
 
 ```bash
-pip install versionable            # Core (JSON backend, numpy)
+pip install versionable            # Core (JSON backend, no heavy deps)
 pip install pyyaml                 # Add YAML backend
 pip install toml                   # Add TOML backend
 pip install h5py hdf5plugin        # Add HDF5 backend

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,13 +46,6 @@ If you're familiar with database migrations, it's the same idea — you'd never 
 migration script. The hash enforces that same discipline for your data files. We recommend using it for any class whose
 data files outlive a single session.
 
-## Why does the base install require numpy?
-
-It shouldn't — this is a known issue ([#17](https://github.com/hendrickmelo/versionable/issues/17)). A future release
-will make numpy optional, required only when using ndarray fields or the HDF5 backend. The base install for config-only
-workflows (JSON, TOML, YAML with scalars and strings) should have zero heavy dependencies. If this matters to you,
-**please upvote the issue** — it helps us prioritize.
-
 ## Can I use this with Python 3.11 or earlier?
 
 Not currently. Versionable requires Python 3.12+ because it uses [PEP 695](https://peps.python.org/pep-0695/) syntax

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -279,4 +279,4 @@ pixi run -- pytest -k "test_name"        # Single test by name
 - Versionable types use their serialization `name` in hashes — stable across file moves
 - Lazy HDF5 loading via dynamically created subclass with `__getattribute__` override
 - `save()`/`load()` accessed via qualified import (`import versionable`), not direct import
-- numpy is a base dependency; HDF5 support (`h5py`, `hdf5plugin`) is optional via `[hdf5]` extra
+- numpy is optional — auto-detected if installed; HDF5 extra (`[hdf5]`) pulls it in with `h5py` and `hdf5plugin`

--- a/pixi.lock
+++ b/pixi.lock
@@ -696,25 +696,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py313h3dea7bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
@@ -755,7 +748,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: ./
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
@@ -775,24 +767,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-6_he492b99_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-6_h9b27e0a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.2-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.5-hcc62823_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-6_h859234e_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.32-openmp_h9e49c7b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.52.0-h77d7759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.2-h0d3cbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py313h035b7d0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py313hb870fc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
@@ -833,7 +816,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: ./
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
@@ -854,24 +836,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-6_h51639a9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-6_hb0561ab_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.2-hc7d1edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py313h65a2061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
@@ -931,24 +904,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-6_hf2e6a31_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-6_h2a3cdd5_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.5-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-6_hf9ab0e9_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.2-h4fa8253_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.3-py313hd650c13_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.1-hac47afa_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.3-py313ha8dc839_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
@@ -967,7 +929,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -1012,24 +973,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
@@ -1037,7 +992,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-25.8.2-he4ff34a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1058,7 +1012,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
       - pypi: ./
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
@@ -1067,30 +1020,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260107.1-cxx17_h7ed6875_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.11.0-6_he492b99_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.11.0-6_h9b27e0a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.2-h19cb2f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.5-hcc62823_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.11.0-6_h859234e_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.2-h11316ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h70048d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.32-openmp_h9e49c7b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.52.0-h77d7759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.51.0-h58003a5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-22.1.2-h0d3cbff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-25.8.2-hf3170e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py313hb870fc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1111,7 +1055,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
       - pypi: ./
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
@@ -1120,30 +1063,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-6_h51639a9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-6_hb0561ab_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h8f3e76b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.2-hc7d1edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-25.8.2-h7039424_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1169,24 +1103,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.11.0-6_hf2e6a31_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.11.0-6_h2a3cdd5_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.5-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.11.0-6_hf9ab0e9_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/llvm-openmp-22.1.2-h4fa8253_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2025.3.1-hac47afa_11.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-25.8.2-h80d1838_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.3-py313ha8dc839_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -1195,7 +1118,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.12-h09917c8_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.15.9-h02f8532_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -5103,25 +5025,6 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 7987602
   timestamp: 1773839174587
-- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py313hb870fc3_0.conda
-  sha256: 2ef07192b3e53dd783438fcc4c18cb9fcbb40ee39c5db024e9e78c0adb047e33
-  md5: a8edd94da68a8ea91e35889708959578
-  depends:
-  - python
-  - __osx >=11.0
-  - libcxx >=19
-  - libblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - python_abi 3.13.* *_cp313
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy?source=compressed-mapping
-  size: 8064515
-  timestamp: 1773839158532
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
   sha256: d55c3f4b13486bf8e3cadaf731a5d9b67aa9deb51f7c30e381b948a9ada20ef0
   md5: 03b99caf1270c27febfcceb4f1090af7
@@ -6652,13 +6555,18 @@ packages:
 - pypi: ./
   name: versionable
   version: 0.1.1.dev1
-  sha256: 86f37afa7a162985021a87d289d6b0234f0979c25ec65cb8f8e4e321ccb55679
+  sha256: 4288749d1a8d880153cc30ab89c9e653bec8c605346fb8961b638e3615d62807
   requires_dist:
-  - numpy>=1.26
   - toml>=0.10 ; extra == 'toml'
   - pyyaml>=6.0 ; extra == 'yaml'
+  - numpy>=1.26 ; extra == 'hdf5'
   - h5py>=3.10 ; extra == 'hdf5'
   - hdf5plugin>=4.0 ; extra == 'hdf5'
+  - numpy>=1.26 ; extra == 'all'
+  - h5py>=3.10 ; extra == 'all'
+  - hdf5plugin>=4.0 ; extra == 'all'
+  - toml>=0.10 ; extra == 'all'
+  - pyyaml>=6.0 ; extra == 'all'
   - sphinx>=7 ; extra == 'docs'
   - myst-parser>=2 ; extra == 'docs'
   - furo ; extra == 'docs'

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,7 +26,6 @@ ci-all = { cmd = "pixi run -e default ci && pixi run -e minimal ci", description
 
 [dependencies]
 python = ">=3.12,<3.14"
-numpy = ">=1.26"
 
 [feature.toml.dependencies]
 toml = ">=0.10"
@@ -35,6 +34,7 @@ toml = ">=0.10"
 pyyaml = ">=6.0"
 
 [feature.hdf5.dependencies]
+numpy = ">=1.26"
 h5py = ">=3.10"
 
 [feature.hdf5.pypi-dependencies]
@@ -72,9 +72,10 @@ sphinx-autobuild = "*"
 docs = "sphinx-build -b html docs docs/_build/html"
 docs-live = "sphinx-autobuild docs docs/_build/html"
 
-# The minimal env doesn't have h5py/hdf5plugin, so pyright can't resolve those
-# imports. We use a separate config (pyrightconfig.minimal.json) that excludes
-# HDF5 files. The full env uses pyproject.toml's [tool.pyright] which checks all files.
+# The minimal env doesn't have numpy/h5py/hdf5plugin, so pyright can't resolve
+# those imports. We use a separate config (pyrightconfig.minimal.json) that
+# excludes numpy/HDF5 files. The full env uses pyproject.toml's [tool.pyright]
+# which checks all files.
 [feature.minimal.tasks]
 pyright = "npx pyright -p pyrightconfig.minimal.json src/"
 ci = { depends-on = ["format_check", "ruff_check", "mypy", "pyright", "prettier_check", "mdlint_check", "test"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["serialization", "dataclass", "hdf5", "toml", "json", "schema", "migration"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -22,14 +22,13 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-dependencies = [
-    "numpy>=1.26",
-]
+dependencies = []
 
 [project.optional-dependencies]
 toml = ["toml>=0.10"]
 yaml = ["pyyaml>=6.0"]
-hdf5 = ["h5py>=3.10", "hdf5plugin>=4.0"]
+hdf5 = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0"]
+all = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0", "toml>=0.10", "pyyaml>=6.0"]
 docs = ["sphinx>=7", "myst-parser>=2", "furo"]
 dev = [
     "pytest>=8.0",
@@ -84,7 +83,7 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 
 [[tool.mypy.overrides]]
-module = ["h5py.*", "hdf5plugin.*", "toml.*", "yaml.*"]
+module = ["numpy.*", "h5py.*", "hdf5plugin.*", "toml.*", "yaml.*"]
 ignore_missing_imports = true
 
 

--- a/pyrightconfig.minimal.json
+++ b/pyrightconfig.minimal.json
@@ -1,13 +1,14 @@
-// Pyright config for the minimal pixi environment (no toml/pyyaml/h5py/hdf5plugin).
-// Files that import optional backend dependencies are excluded here because
-// those packages aren't installed in the minimal env. The full environment
-// uses pyproject.toml's [tool.pyright] section, which checks all files.
+// Pyright config for the minimal pixi environment (no numpy/toml/pyyaml/h5py/hdf5plugin).
+// Files that import optional dependencies are excluded here because those
+// packages aren't installed in the minimal env. The full environment uses
+// pyproject.toml's [tool.pyright] section, which checks all files.
 {
   "include": ["src"],
   "exclude": [
     "**/node_modules",
     "**/__pycache__",
     "**/.*",
+    "src/versionable/_numpy_compat.py",
     "src/versionable/_toml_backend.py",
     "src/versionable/_yaml_backend.py",
     "src/versionable/_hdf5_backend.py",

--- a/src/versionable/_hdf5_field.py
+++ b/src/versionable/_hdf5_field.py
@@ -20,8 +20,6 @@ import typing
 from dataclasses import dataclass
 from typing import Annotated, Any
 
-import numpy as np
-
 from versionable.errors import BackendError
 
 TARGET_CHUNK_BYTES = 256 * 1024  # 256 KB
@@ -82,10 +80,12 @@ def _resolveAppendAxis(shape: tuple[int, ...], hdf5Field: Hdf5FieldInfo) -> int:
     return 0
 
 
-def _computeChunkSize(shape: tuple[int, ...], dtype: np.dtype[Any], axis: int) -> int:
+def _computeChunkSize(shape: tuple[int, ...], dtype: Any, axis: int) -> int:
     """Compute elements per chunk along the append axis targeting TARGET_CHUNK_BYTES."""
+    import numpy as np  # deferred to keep Hdf5FieldInfo importable without numpy
+
     nonAppendShape = shape[:axis] + shape[axis + 1 :]
     sliceBytes = int(np.prod(nonAppendShape)) * dtype.itemsize if nonAppendShape else dtype.itemsize
     if sliceBytes == 0:
         return 1
-    return max(1, TARGET_CHUNK_BYTES // sliceBytes)
+    return int(max(1, TARGET_CHUNK_BYTES // sliceBytes))

--- a/src/versionable/_numpy_compat.py
+++ b/src/versionable/_numpy_compat.py
@@ -1,0 +1,29 @@
+"""Numpy availability helpers.
+
+Centralises the try/except for numpy so every module uses the same
+pattern and error message.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+try:
+    import numpy
+
+    _np: types.ModuleType | None = numpy
+except ImportError:
+    _np = None
+
+
+def hasNumpy() -> bool:
+    """Return True if numpy is installed."""
+    return _np is not None
+
+
+def requireNumpy(feature: str = "This feature") -> Any:
+    """Return the numpy module, or raise ImportError with a clear message."""
+    if _np is None:
+        raise ImportError(f"{feature} requires numpy. Install it with: pip install numpy")
+    return _np

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -19,9 +19,9 @@ from enum import Enum
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Protocol, runtime_checkable
 
-import numpy as np
-
 from versionable._base import Versionable, _resolveFields
+from versionable._numpy_compat import _np as np
+from versionable._numpy_compat import requireNumpy
 from versionable.errors import ConverterError
 
 logger = logging.getLogger(__name__)
@@ -251,7 +251,7 @@ def _serializeTyped(value: Any, nativeTypes: set[type]) -> Any:
         return value.value
     if isinstance(value, Versionable):
         return _serializeVersionable(value)
-    if isinstance(value, np.ndarray):
+    if np is not None and isinstance(value, np.ndarray):
         return _serializeNdarray(value)
 
     return _UNHANDLED
@@ -394,7 +394,9 @@ def _deserializeConcrete(
         return _deserializeVersionable(data, concreteType)
 
     # numpy ndarray (both explicit ndarray and npt.NDArray alias)
-    if concreteType is np.ndarray or (isinstance(concreteType, type) and issubclass(concreteType, np.ndarray)):
+    if np is not None and (
+        concreteType is np.ndarray or (isinstance(concreteType, type) and issubclass(concreteType, np.ndarray))
+    ):
         return _deserializeNdarray(data)
 
     # Collections
@@ -509,25 +511,26 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
 # ---------------------------------------------------------------------------
 
 
-def _serializeNdarray(arr: np.ndarray) -> dict[str, Any]:
+def _serializeNdarray(arr: Any) -> dict[str, Any]:
     """Serialize a numpy array to a base64-encoded npz representation."""
+    numpy = requireNumpy("ndarray serialization")
     buf = io.BytesIO()
-    np.savez_compressed(buf, data=arr)
+    numpy.savez_compressed(buf, data=arr)
     encoded = base64.b64encode(buf.getvalue()).decode("ascii")
     return {"__ndarray__": True, "dtype": str(arr.dtype), "shape": list(arr.shape), "data": encoded}
 
 
-def _deserializeNdarray(data: Any) -> np.ndarray:
+def _deserializeNdarray(data: Any) -> Any:
     """Deserialize a numpy array from its serialized representation."""
-    if isinstance(data, np.ndarray):
+    numpy = requireNumpy("ndarray deserialization")
+    if isinstance(data, numpy.ndarray):
         return data
     if isinstance(data, dict) and data.get("__ndarray__"):
         raw = base64.b64decode(data["data"])
         buf = io.BytesIO(raw)
-        arr: np.ndarray = np.load(buf)["data"]
-        return arr
+        return numpy.load(buf)["data"]
     if isinstance(data, list):
-        return np.asarray(data)
+        return numpy.asarray(data)
     raise ConverterError(f"Cannot deserialize ndarray from {type(data).__name__}")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal
 
-import numpy as np  # noqa: TC002 — needed at runtime for NDArray type resolution
-import numpy.typing as npt  # noqa: TC002
-
 from versionable._base import Versionable
 from versionable._types import literalFallback
 
@@ -32,17 +29,6 @@ class WithOptional(
 ):
     label: str
     description: str | None = None
-
-
-@dataclass
-class WithArray(
-    Versionable,
-    version=1,
-    hash="c0dc53",
-    register=False,
-):
-    name: str
-    data: npt.NDArray[np.float64]
 
 
 class Priority(Enum):

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -16,9 +16,15 @@ from pathlib import Path, PurePosixPath
 from typing import Literal
 from uuid import UUID
 
-import numpy as np
-import numpy.typing as npt
 import pytest
+
+try:
+    import numpy as np
+    import numpy.typing as npt
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
 
 import versionable
 from versionable import Versionable
@@ -83,13 +89,15 @@ class _WithOptional(Versionable, version=1, hash="c599a5", register=False):
     count: int | None = None
 
 
-@dataclass
-class _WithArrays(Versionable, version=1, hash="e9fc06", register=False):
-    name: str
-    data: npt.NDArray[np.float64]
-    matrix: npt.NDArray[np.int32]
-    traces: list[npt.NDArray[np.float64]]
-    channels: dict[str, npt.NDArray[np.float64]]
+if _HAS_NUMPY:
+
+    @dataclass
+    class _WithArrays(Versionable, version=1, hash="e9fc06", register=False):
+        name: str
+        data: npt.NDArray[np.float64]
+        matrix: npt.NDArray[np.int32]
+        traces: list[npt.NDArray[np.float64]]
+        channels: dict[str, npt.NDArray[np.float64]]
 
 
 @dataclass
@@ -147,20 +155,20 @@ def _assertFieldMatch(original: object, loaded: object, fieldName: str, ext: str
     orig = getattr(original, fieldName)
     load = getattr(loaded, fieldName)
 
-    if isinstance(orig, np.ndarray):
+    if _HAS_NUMPY and isinstance(orig, np.ndarray):
         assert isinstance(load, np.ndarray), f"[{ext}] {fieldName}: expected np.ndarray, got {type(load).__name__}"
         np.testing.assert_array_equal(load, orig, err_msg=f"[{ext}] {fieldName}")
         assert load.dtype == orig.dtype, f"[{ext}] {fieldName}: dtype mismatch {load.dtype} != {orig.dtype}"
         return
 
-    if isinstance(orig, list) and orig and isinstance(orig[0], np.ndarray):
+    if _HAS_NUMPY and isinstance(orig, list) and orig and isinstance(orig[0], np.ndarray):
         assert isinstance(load, list), f"[{ext}] {fieldName}: expected list, got {type(load).__name__}"
         assert len(load) == len(orig), f"[{ext}] {fieldName}: length mismatch {len(load)} != {len(orig)}"
         for i, (origArr, loadArr) in enumerate(zip(orig, load, strict=True)):
             np.testing.assert_array_equal(loadArr, origArr, err_msg=f"[{ext}] {fieldName}[{i}]")
         return
 
-    if isinstance(orig, dict) and orig and isinstance(next(iter(orig.values())), np.ndarray):
+    if _HAS_NUMPY and isinstance(orig, dict) and orig and isinstance(next(iter(orig.values())), np.ndarray):
         assert isinstance(load, dict), f"[{ext}] {fieldName}: expected dict, got {type(load).__name__}"
         assert set(load.keys()) == set(orig.keys()), f"[{ext}] {fieldName}: key mismatch"
         for k in orig:
@@ -336,118 +344,119 @@ class TestOptionalFieldsRoundtrip:
         assert loaded.count is None
 
 
-class TestArrayFieldsRoundtrip:
-    """Array and array-collection fields across backends."""
+if _HAS_NUMPY:
 
-    @pytest.fixture
-    def obj(self) -> _WithArrays:
-        return _WithArrays(
-            name="arrays",
-            data=np.array([1.0, 2.0, 3.0], dtype=np.float64),
-            matrix=np.array([[1, 2], [3, 4]], dtype=np.int32),
-            traces=[np.array([10.0, 20.0]), np.array([30.0, 40.0, 50.0])],
-            channels={"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])},
+    class TestArrayFieldsRoundtrip:
+        """Array and array-collection fields across backends."""
+
+        @pytest.fixture
+        def obj(self) -> _WithArrays:
+            return _WithArrays(
+                name="arrays",
+                data=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+                matrix=np.array([[1, 2], [3, 4]], dtype=np.int32),
+                traces=[np.array([10.0, 20.0]), np.array([30.0, 40.0, 50.0])],
+                channels={"ch0": np.array([1.0, 2.0]), "ch1": np.array([3.0, 4.0])},
+            )
+
+        @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
+        def test_hdf5Roundtrip(self, obj: _WithArrays, tmp_path: Path) -> None:
+            loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
+            _assertFullMatch(obj, loaded, ".h5")
+
+        @pytest.mark.parametrize("ext", _DICT_BACKENDS)
+        def test_dictBackendRoundtrip(self, obj: _WithArrays, tmp_path: Path, ext: str) -> None:
+            """Dict backends serialize arrays as base64 npz and roundtrip correctly."""
+            loaded = _roundtrip(_WithArrays, obj, tmp_path, ext)
+            np.testing.assert_array_equal(loaded.data, obj.data)
+            assert loaded.data.dtype == obj.data.dtype
+            np.testing.assert_array_equal(loaded.matrix, obj.matrix)
+            assert loaded.matrix.dtype == obj.matrix.dtype
+
+        @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
+        def test_hdf5ArrayDtypes(self, obj: _WithArrays, tmp_path: Path) -> None:
+            """HDF5 preserves exact dtypes."""
+            loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
+            assert loaded.data.dtype == np.float64
+            assert loaded.matrix.dtype == np.int32
+
+    class TestNumpyDtypeRoundtrip:
+        """Verify that various numpy dtypes survive the roundtrip."""
+
+        @pytest.mark.parametrize(
+            "dtype",
+            [
+                np.float32,
+                np.float64,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+                np.bool_,
+                np.complex64,
+                np.complex128,
+            ],
         )
+        @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+        def test_scalarDtype(self, tmp_path: Path, dtype: type, ext: str) -> None:
+            """1-D array of each dtype roundtrips with correct dtype."""
 
-    @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
-    def test_hdf5Roundtrip(self, obj: _WithArrays, tmp_path: Path) -> None:
-        loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
-        _assertFullMatch(obj, loaded, ".h5")
+            @dataclass
+            class DtypeTest(Versionable, version=1, register=False):
+                arr: npt.NDArray[np.generic]
 
-    @pytest.mark.parametrize("ext", _DICT_BACKENDS)
-    def test_dictBackendRoundtrip(self, obj: _WithArrays, tmp_path: Path, ext: str) -> None:
-        """Dict backends serialize arrays as base64 npz and roundtrip correctly."""
-        loaded = _roundtrip(_WithArrays, obj, tmp_path, ext)
-        np.testing.assert_array_equal(loaded.data, obj.data)
-        assert loaded.data.dtype == obj.data.dtype
-        np.testing.assert_array_equal(loaded.matrix, obj.matrix)
-        assert loaded.matrix.dtype == obj.matrix.dtype
+            arr = np.array([1, 2, 3], dtype=dtype)
+            obj = DtypeTest(arr=arr)
+            loaded = _roundtrip(DtypeTest, obj, tmp_path, ext)
+            np.testing.assert_array_equal(loaded.arr, arr)
+            assert loaded.arr.dtype == dtype, f"[{ext}] dtype: {loaded.arr.dtype} != {dtype}"
 
-    @pytest.mark.skipif(not _HDF5_BACKENDS, reason="HDF5 backend not available")
-    def test_hdf5ArrayDtypes(self, obj: _WithArrays, tmp_path: Path) -> None:
-        """HDF5 preserves exact dtypes."""
-        loaded = _roundtrip(_WithArrays, obj, tmp_path, ".h5")
-        assert loaded.data.dtype == np.float64
-        assert loaded.matrix.dtype == np.int32
+        @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+        def test_2dArray(self, tmp_path: Path, ext: str) -> None:
+            """2-D array preserves shape and dtype."""
 
+            @dataclass
+            class Matrix(Versionable, version=1, register=False):
+                matrix: npt.NDArray[np.float64]
 
-class TestNumpyDtypeRoundtrip:
-    """Verify that various numpy dtypes survive the roundtrip."""
+            arr = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
+            obj = Matrix(matrix=arr)
+            loaded = _roundtrip(Matrix, obj, tmp_path, ext)
+            np.testing.assert_array_equal(loaded.matrix, arr)
+            assert loaded.matrix.shape == (3, 2), f"[{ext}] shape: {loaded.matrix.shape}"
 
-    @pytest.mark.parametrize(
-        "dtype",
-        [
-            np.float32,
-            np.float64,
-            np.int8,
-            np.int16,
-            np.int32,
-            np.int64,
-            np.uint8,
-            np.uint16,
-            np.uint32,
-            np.uint64,
-            np.bool_,
-            np.complex64,
-            np.complex128,
-        ],
-    )
-    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
-    def test_scalarDtype(self, tmp_path: Path, dtype: type, ext: str) -> None:
-        """1-D array of each dtype roundtrips with correct dtype."""
+        @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+        def test_3dArray(self, tmp_path: Path, ext: str) -> None:
+            """3-D array preserves shape."""
 
-        @dataclass
-        class DtypeTest(Versionable, version=1, register=False):
-            arr: npt.NDArray[np.generic]
+            @dataclass
+            class Cube(Versionable, version=1, register=False):
+                cube: npt.NDArray[np.float32]
 
-        arr = np.array([1, 2, 3], dtype=dtype)
-        obj = DtypeTest(arr=arr)
-        loaded = _roundtrip(DtypeTest, obj, tmp_path, ext)
-        np.testing.assert_array_equal(loaded.arr, arr)
-        assert loaded.arr.dtype == dtype, f"[{ext}] dtype: {loaded.arr.dtype} != {dtype}"
+            arr = np.ones((2, 3, 4), dtype=np.float32)
+            obj = Cube(cube=arr)
+            loaded = _roundtrip(Cube, obj, tmp_path, ext)
+            np.testing.assert_array_equal(loaded.cube, arr)
+            assert loaded.cube.shape == (2, 3, 4), f"[{ext}] shape: {loaded.cube.shape}"
+            assert loaded.cube.dtype == np.float32, f"[{ext}] dtype: {loaded.cube.dtype}"
 
-    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
-    def test_2dArray(self, tmp_path: Path, ext: str) -> None:
-        """2-D array preserves shape and dtype."""
+        @pytest.mark.parametrize("ext", _ALL_BACKENDS)
+        def test_emptyArray(self, tmp_path: Path, ext: str) -> None:
+            """Zero-length array preserves dtype."""
 
-        @dataclass
-        class Matrix(Versionable, version=1, register=False):
-            matrix: npt.NDArray[np.float64]
+            @dataclass
+            class EmptyArr(Versionable, version=1, register=False):
+                arr: npt.NDArray[np.float64]
 
-        arr = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float64)
-        obj = Matrix(matrix=arr)
-        loaded = _roundtrip(Matrix, obj, tmp_path, ext)
-        np.testing.assert_array_equal(loaded.matrix, arr)
-        assert loaded.matrix.shape == (3, 2), f"[{ext}] shape: {loaded.matrix.shape}"
-
-    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
-    def test_3dArray(self, tmp_path: Path, ext: str) -> None:
-        """3-D array preserves shape."""
-
-        @dataclass
-        class Cube(Versionable, version=1, register=False):
-            cube: npt.NDArray[np.float32]
-
-        arr = np.ones((2, 3, 4), dtype=np.float32)
-        obj = Cube(cube=arr)
-        loaded = _roundtrip(Cube, obj, tmp_path, ext)
-        np.testing.assert_array_equal(loaded.cube, arr)
-        assert loaded.cube.shape == (2, 3, 4), f"[{ext}] shape: {loaded.cube.shape}"
-        assert loaded.cube.dtype == np.float32, f"[{ext}] dtype: {loaded.cube.dtype}"
-
-    @pytest.mark.parametrize("ext", _ALL_BACKENDS)
-    def test_emptyArray(self, tmp_path: Path, ext: str) -> None:
-        """Zero-length array preserves dtype."""
-
-        @dataclass
-        class EmptyArr(Versionable, version=1, register=False):
-            arr: npt.NDArray[np.float64]
-
-        arr = np.array([], dtype=np.float64)
-        obj = EmptyArr(arr=arr)
-        loaded = _roundtrip(EmptyArr, obj, tmp_path, ext)
-        assert len(loaded.arr) == 0
-        assert loaded.arr.dtype == np.float64, f"[{ext}] dtype: {loaded.arr.dtype}"
+            arr = np.array([], dtype=np.float64)
+            obj = EmptyArr(arr=arr)
+            loaded = _roundtrip(EmptyArr, obj, tmp_path, ext)
+            assert len(loaded.arr) == 0
+            assert loaded.arr.dtype == np.float64, f"[{ext}] dtype: {loaded.arr.dtype}"
 
 
 class TestEmptyCollectionsRoundtrip:

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -6,8 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-import numpy as np
-import numpy.typing as npt
+import pytest
 
 from versionable._hash import canonicalTypeName, computeHash
 
@@ -93,10 +92,14 @@ class TestCanonicalTypeName:
         assert result == "list[dict[str, int]]"
 
     def test_numpyNdarray(self) -> None:
+        np = pytest.importorskip("numpy")
         result = canonicalTypeName(np.ndarray)
         assert result == "ndarray"
 
     def test_numpyTypedArray(self) -> None:
+        np = pytest.importorskip("numpy")
+        import numpy.typing as npt
+
         result = canonicalTypeName(npt.NDArray[np.float64])
         assert "ndarray" in result
 

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -26,7 +26,19 @@ from versionable.hdf5 import (
     Hdf5Compression,
 )
 
-from .conftest import Inner, SimpleConfig, WithArray, WithNested
+from .conftest import Inner, SimpleConfig, WithNested
+
+
+@dataclass
+class WithArray(
+    Versionable,
+    version=1,
+    hash="c0dc53",
+    register=False,
+):
+    name: str
+    data: npt.NDArray[np.float64]
+
 
 # Module-level classes for tests that need type resolution across nested Versionables.
 # Defining inside test functions causes forward-reference resolution failures with

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -11,7 +11,6 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
 import pytest
 
 from versionable._base import Versionable
@@ -225,7 +224,10 @@ class TestCollections:
 
 
 class TestNdarray:
+    np = pytest.importorskip("numpy")
+
     def test_roundtrip(self) -> None:
+        np = self.np
         arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
         serialized = serialize(arr, np.ndarray)
         assert isinstance(serialized, dict)
@@ -234,6 +236,7 @@ class TestNdarray:
         np.testing.assert_array_equal(result, arr)
 
     def test_2dArray(self) -> None:
+        np = self.np
         arr = np.array([[1, 2], [3, 4]], dtype=np.int32)
         serialized = serialize(arr, np.ndarray)
         result = deserialize(serialized, np.ndarray)
@@ -241,11 +244,13 @@ class TestNdarray:
 
     def test_nativeBypass(self) -> None:
         """If ndarray is in nativeTypes, it passes through."""
+        np = self.np
         arr = np.array([1.0, 2.0])
         result = serialize(arr, np.ndarray, nativeTypes={np.ndarray})
         assert isinstance(result, np.ndarray)
 
     def test_fromList(self) -> None:
+        np = self.np
         result = deserialize([1, 2, 3], np.ndarray)
         np.testing.assert_array_equal(result, np.array([1, 2, 3]))
 


### PR DESCRIPTION
**Description:** Make numpy optional so the base install works without it. Users who only need versioned configs (JSON/TOML/YAML with scalars, strings, lists) no longer pay the ~30 MB numpy install tax. If numpy is installed in the environment, versionable automatically picks it up for ndarray field support.

**Changes:**

- Move numpy from `dependencies` to optional (auto-detected; `hdf5` extra pulls it in)
- Add `_numpy_compat.py` helper for conditional numpy availability
- Guard numpy usage in `_types.py` behind availability checks
- Defer numpy import in `_hdf5_field.py` to keep `Hdf5FieldInfo` importable without numpy
- Update pixi.toml, pyrightconfig.minimal.json, and mypy overrides
- Move numpy-dependent test fixtures/classes behind `importorskip` guards
- Remove outdated FAQ entry about numpy requirement
- Update README, AGENT.md, and skills.md to reflect optional numpy
- Bump development status from Alpha to Beta

**Tests performed:**

- `ci-all` passes: 393 passed (default), 92 passed + 11 skipped (minimal)
- Verified `import versionable` works without numpy in minimal env
- Numpy-dependent tests properly skip when numpy is absent

Closes #17