### PR TITLE
Clarify HDF5 load errors when hdf5plugin is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   new keys.
 - The warning emitted by `load()` for files missing version metadata now reads `No version found …` (was
   `No __VERSION__ found …`).
+- HDF5 backend now auto-registers `hdf5plugin` filters on import, so files written with zstd/blosc compression can be
+  read without the consumer having to import `hdf5plugin` themselves. When `hdf5plugin` is missing and a load fails on a
+  filter-related error, the raised `BackendError` now suggests `pip install hdf5plugin` (#20).
 
 ## 0.1.0
 

--- a/pyrightconfig.minimal.json
+++ b/pyrightconfig.minimal.json
@@ -13,6 +13,7 @@
     "src/versionable/_yaml_backend.py",
     "src/versionable/_hdf5_backend.py",
     "src/versionable/_hdf5_compression.py",
+    "src/versionable/_hdf5_plugin.py",
     "src/versionable/_hdf5_session.py",
     "src/versionable/_dataset_array.py",
     "src/versionable/_hdf5_field.py",

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -39,6 +39,11 @@ import numpy as np
 from versionable._backend import Backend, registerBackend
 from versionable._base import Versionable, _resolveFields, metadata
 from versionable._hdf5_compression import DEFAULT_COMPRESSION, Hdf5Compression
+
+# Importing ``_hdf5_plugin`` registers optional HDF5 compression filter plugins
+# (zstd, blosc, etc.) so that files written with those filters can be read
+# without the consumer having to import ``hdf5plugin`` manually.
+from versionable._hdf5_plugin import missingFilterHint
 from versionable._lazy import ArrayNotLoaded, LazyArray, LazyContext
 from versionable._types import _appendField, _appendIndex, _appendKey, _registry
 from versionable.errors import BackendError, CircularReferenceError
@@ -99,7 +104,7 @@ class Hdf5Backend(Backend):
                 fields, _ = _readFields(f, fieldTypes)
             return fields, meta
         except OSError as e:
-            raise BackendError(f"Failed to read HDF5 from {path}: {e}") from e
+            raise BackendError(f"Failed to read HDF5 from {path}: {e}{missingFilterHint(e)}") from e
 
     def loadLazy(
         self,
@@ -137,7 +142,7 @@ class Hdf5Backend(Backend):
 
             return fields, meta, lazyFields
         except OSError as e:
-            raise BackendError(f"Failed to read HDF5 from {path}: {e}") from e
+            raise BackendError(f"Failed to read HDF5 from {path}: {e}{missingFilterHint(e)}") from e
 
 
 # ---------------------------------------------------------------------------

--- a/src/versionable/_hdf5_plugin.py
+++ b/src/versionable/_hdf5_plugin.py
@@ -13,13 +13,17 @@ turns that into a clear "install hdf5plugin" message.
 
 from __future__ import annotations
 
-import contextlib
-
+# hdf5plugin can fail with OSError (not just ImportError) when its bundled native
+# shared libraries can't be loaded — e.g. dlopen "undefined symbol" against an
+# incompatible libhdf5. Catch both so a broken install of the optional dependency
+# doesn't crash the whole HDF5 backend.
 HDF5PLUGIN_AVAILABLE = False
-with contextlib.suppress(ImportError):
+try:
     import hdf5plugin  # noqa: F401  — side-effect import: registers HDF5 filter plugins
 
     HDF5PLUGIN_AVAILABLE = True
+except (ImportError, OSError):
+    pass
 
 
 _FILTER_ERROR_KEYWORDS = ("filter", "pipeline", "plugin")

--- a/src/versionable/_hdf5_plugin.py
+++ b/src/versionable/_hdf5_plugin.py
@@ -1,0 +1,45 @@
+"""HDF5 compression filter plugin registration and error hinting.
+
+Importing this module attempts to import ``hdf5plugin`` as a side effect, which
+registers its compression filter plugins (zstd, blosc, etc.) with the HDF5
+library. Consumers of the HDF5 backend then do not need to import
+``hdf5plugin`` themselves to read files that use those filters.
+
+If ``hdf5plugin`` is not installed, the backend still works for files that use
+built-in filters (gzip, lzf, uncompressed). Attempts to read files that use a
+plugin filter will raise an ``OSError`` from h5py; :func:`missingFilterHint`
+turns that into a clear "install hdf5plugin" message.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+HDF5PLUGIN_AVAILABLE = False
+with contextlib.suppress(ImportError):
+    import hdf5plugin  # noqa: F401  — side-effect import: registers HDF5 filter plugins
+
+    HDF5PLUGIN_AVAILABLE = True
+
+
+_FILTER_ERROR_KEYWORDS = ("filter", "pipeline", "plugin")
+
+_INSTALL_HINT = (
+    " This file appears to use a compression filter (e.g. zstd, blosc) that requires "
+    "the hdf5plugin package. Install it with: `pip install hdf5plugin`."
+)
+
+
+def missingFilterHint(exc: BaseException) -> str:
+    """Return an install hint when *exc* looks like a missing HDF5 filter error.
+
+    Returns an empty string when ``hdf5plugin`` is already installed (the error
+    is not caused by a missing plugin) or when *exc*'s message does not match
+    the filter-error keywords.
+    """
+    if HDF5PLUGIN_AVAILABLE:
+        return ""
+    msg = str(exc).lower()
+    if any(kw in msg for kw in _FILTER_ERROR_KEYWORDS):
+        return _INSTALL_HINT
+    return ""

--- a/src/versionable/_hdf5_session.py
+++ b/src/versionable/_hdf5_session.py
@@ -41,6 +41,7 @@ from versionable._hdf5_field import (
     _getHdf5FieldInfo,
     _resolveAppendAxis,
 )
+from versionable._hdf5_plugin import missingFilterHint
 from versionable._types import _appendIndex, _appendKey
 from versionable.errors import BackendError
 
@@ -188,7 +189,10 @@ class Hdf5Session[T: Versionable]:
             raise BackendError(f"Cannot resume: file has hash {fileMeta['hash']!r}, but class has hash {meta.hash!r}.")
 
         # Load existing fields
-        fields, _ = _readFields(self._root, self._fieldTypes)
+        try:
+            fields, _ = _readFields(self._root, self._fieldTypes)
+        except OSError as e:
+            raise BackendError(f"Failed to read HDF5 from {self._path}: {e}{missingFilterHint(e)}") from e
 
         # Populate proxy and wrap with tracked proxies
         for name, value in fields.items():

--- a/src/versionable/_lazy.py
+++ b/src/versionable/_lazy.py
@@ -16,6 +16,7 @@ The mechanism uses a dynamically created subclass that overrides
 from __future__ import annotations
 
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
@@ -23,11 +24,26 @@ from typing import TYPE_CHECKING, Any, overload
 import h5py
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import numpy as np
 
-from versionable.errors import ArrayNotLoadedError
+from versionable._hdf5_plugin import missingFilterHint
+from versionable.errors import ArrayNotLoadedError, BackendError
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _rewrapFilterErrors(filePath: Path) -> Iterator[None]:
+    """Re-raise filter-related OSError as BackendError with a hdf5plugin install hint."""
+    try:
+        yield
+    except OSError as e:
+        hint = missingFilterHint(e)
+        if hint:
+            raise BackendError(f"Failed to read HDF5 from {filePath}: {e}{hint}") from e
+        raise
 
 
 def _loadDataset(f: h5py.File, path: str) -> np.ndarray:
@@ -75,7 +91,7 @@ class LazyArray:
         self.datasetPath = datasetPath
 
     def load(self) -> np.ndarray:
-        with h5py.File(self.filePath, "r") as f:
+        with _rewrapFilterErrors(self.filePath), h5py.File(self.filePath, "r") as f:
             return _loadDataset(f, self.datasetPath)
 
     def __repr__(self) -> str:
@@ -115,7 +131,7 @@ class LazyArrayList:
             raise IndexError(f"index {index} out of range for LazyArrayList of length {len(self)}")
         if index not in self._cache:
             key = self._keys[index]
-            with h5py.File(self.filePath, "r") as f:
+            with _rewrapFilterErrors(self.filePath), h5py.File(self.filePath, "r") as f:
                 self._cache[index] = _loadDataset(f, f"{self.groupPath}/{key}")
             logger.debug("Lazy-loaded %s/%s", self.groupPath, key)
         return self._cache[index]
@@ -162,7 +178,7 @@ class LazyArrayDict:
             if key not in self._keyToHdf5:
                 raise KeyError(key)
             hdf5Key = self._keyToHdf5[key]
-            with h5py.File(self.filePath, "r") as f:
+            with _rewrapFilterErrors(self.filePath), h5py.File(self.filePath, "r") as f:
                 self._cache[key] = _loadDataset(f, f"{self.groupPath}/{hdf5Key}")
             logger.debug("Lazy-loaded %s/%s", self.groupPath, hdf5Key)
         return self._cache[key]

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -160,6 +160,53 @@ class TestHdf5Compression:
             assert ds.compression == "gzip"
             assert ds.compression_opts == 4
 
+    def test_hdf5pluginAutoRegistered(self) -> None:
+        """Importing the HDF5 backend should register hdf5plugin filters.
+
+        Uses a subprocess for a clean interpreter — otherwise pytest's own
+        imports might pollute sys.modules and hide the bug this fix prevents.
+        """
+        pytest.importorskip("hdf5plugin")
+        import subprocess
+        import sys
+
+        code = "from versionable import _hdf5_backend; import sys; assert 'hdf5plugin' in sys.modules"
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    def test_missingFilterHintSuggestsPipInstall(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When hdf5plugin is missing, filter-related errors should suggest installing it."""
+        from versionable import _hdf5_plugin
+
+        monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
+
+        # Simulate an h5py filter error
+        err = OSError("Can't read data (filter not available)")
+        hint = _hdf5_plugin.missingFilterHint(err)
+        assert "pip install hdf5plugin" in hint
+
+        # Non-filter OSError → no hint
+        other = OSError("Permission denied")
+        assert _hdf5_plugin.missingFilterHint(other) == ""
+
+    def test_loadErrorIncludesHdf5pluginHint(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """load() surfaces the hdf5plugin install hint for filter-related failures."""
+        from versionable import _hdf5_plugin
+
+        monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
+
+        # Craft a file that triggers a filter-like OSError by poisoning h5py.File
+        p = tmp_path / "needs-plugin.h5"
+        obj = SimpleConfig(name="x", debug=False, retries=0)
+        versionable.save(obj, p)
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("Can't read data (filter 'zstd' not available)")
+
+        monkeypatch.setattr("versionable._hdf5_backend.h5py.File", boom)
+        with pytest.raises(BackendError, match=r"pip install hdf5plugin"):
+            versionable.load(SimpleConfig, p)
+
 
 class TestLazyLoading:
     def test_lazyByDefault(self, tmp_path: Path) -> None:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -214,6 +214,29 @@ class TestHdf5Compression:
         with pytest.raises(BackendError, match=r"pip install hdf5plugin"):
             versionable.load(SimpleConfig, p)
 
+    def test_sessionResumeErrorIncludesHdf5pluginHint(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Session resume surfaces the hdf5plugin install hint for filter-related failures."""
+        import versionable.hdf5
+        from versionable import _hdf5_plugin
+
+        monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
+
+        # Save a file normally so resume gets past the metadata-validation step
+        p = tmp_path / "needs-plugin.h5"
+        obj = SimpleConfig(name="x", debug=False, retries=0)
+        versionable.save(obj, p)
+
+        # Make the resume-time field read raise a filter-like OSError
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("Can't read data (filter 'zstd' not available)")
+
+        monkeypatch.setattr("versionable._hdf5_session._readFields", boom)
+        with (
+            pytest.raises(BackendError, match=r"pip install hdf5plugin"),
+            versionable.hdf5.open(SimpleConfig, p, mode="resume"),
+        ):
+            pass
+
 
 class TestLazyLoading:
     def test_lazyByDefault(self, tmp_path: Path) -> None:

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -165,12 +165,19 @@ class TestHdf5Compression:
 
         Uses a subprocess for a clean interpreter — otherwise pytest's own
         imports might pollute sys.modules and hide the bug this fix prevents.
+        Asserts hdf5plugin is *not* loaded before the backend import to prove
+        the backend itself is what triggered registration.
         """
         pytest.importorskip("hdf5plugin")
         import subprocess
         import sys
 
-        code = "from versionable import _hdf5_backend; import sys; assert 'hdf5plugin' in sys.modules"
+        code = (
+            "import sys; "
+            "assert 'hdf5plugin' not in sys.modules, 'hdf5plugin pre-loaded by startup hook'; "
+            "from versionable import _hdf5_backend; "
+            "assert 'hdf5plugin' in sys.modules, 'backend did not import hdf5plugin'"
+        )
         result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
         assert result.returncode == 0, f"stderr: {result.stderr}"
 

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -18,7 +18,8 @@ import numpy as np
 import numpy.typing as npt
 
 import versionable
-from versionable import Versionable
+import versionable.hdf5
+from versionable import Versionable, _hdf5_plugin
 from versionable.errors import ArrayNotLoadedError, BackendError
 from versionable.hdf5 import (
     UNCOMPRESSED,
@@ -183,8 +184,6 @@ class TestHdf5Compression:
 
     def test_missingFilterHintSuggestsPipInstall(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When hdf5plugin is missing, filter-related errors should suggest installing it."""
-        from versionable import _hdf5_plugin
-
         monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
 
         # Simulate an h5py filter error
@@ -198,8 +197,6 @@ class TestHdf5Compression:
 
     def test_loadErrorIncludesHdf5pluginHint(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """load() surfaces the hdf5plugin install hint for filter-related failures."""
-        from versionable import _hdf5_plugin
-
         monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
 
         # Craft a file that triggers a filter-like OSError by poisoning h5py.File
@@ -216,9 +213,6 @@ class TestHdf5Compression:
 
     def test_sessionResumeErrorIncludesHdf5pluginHint(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Session resume surfaces the hdf5plugin install hint for filter-related failures."""
-        import versionable.hdf5
-        from versionable import _hdf5_plugin
-
         monkeypatch.setattr(_hdf5_plugin, "HDF5PLUGIN_AVAILABLE", False)
 
         # Save a file normally so resume gets past the metadata-validation step


### PR DESCRIPTION
**Description:** Fixes #20. Auto-register hdf5plugin filters when the HDF5 backend loads, and produce a clear "pip install hdf5plugin" hint when a load fails because of a missing filter.

**Changes:**

- Add `_hdf5_plugin.py` with side-effect `import hdf5plugin` and a `missingFilterHint()` helper
- Wrap every HDF5 read path (`load`, `loadLazy`, session resume, `LazyArray`, `LazyArrayList`, `LazyArrayDict`) to surface the install hint on filter-related `OSError`s
- Add `_hdf5_plugin.py` to the minimal-env pyright excludes alongside other HDF5 files

**Tests performed:**

- New tests verify auto-registration via subprocess, helper behavior, and end-to-end error message
- Full suite: 396 passed (default env), 145 passed (minimal env)