### PR TITLE
Rename file-format envelope keys; drop dunders inside __versionable__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   `__VERSION__` → `version`, `__HASH__` → `hash`, `__FORMAT__` → `format`), and re-namespaced the user-data sentinels
   with a `__ver_*__` prefix (`__ndarray__` → `__ver_ndarray__`, `__json__` → `__ver_json__`). The `__versionable__`
   wrapper key itself is unchanged.
+- File format: nested `Versionable` values now carry their own `__versionable__` envelope, just like the root.
+  Previously the envelope keys were flat alongside data fields in JSON/YAML/TOML; HDF5 already wrapped at every level.
+  For TOML this is emitted as a `[parent.__versionable__]` sub-table. The deserialize path is structurally unchanged —
+  envelope keys are skipped during field iteration whether flat or wrapped, so 0.1.x files (with flat nested envelopes)
+  continue to load.
 - Backwards compatibility: `load()` continues to accept the old key names from 0.1.x files for the entire 0.2.x line
   (preferring new keys when both are present); the legacy read path will be removed in 1.0. Saved files always use the
   new keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
   of `RecursionError`. Detection covers all four backends (JSON, YAML, TOML, HDF5).
 - Shared references are still duplicated on save and load as separate instances. Lossless shared-reference support (and
   therefore cycles, on opt-in) is planned for 0.3.0.
+- File format: dropped the redundant dunders inside the `__versionable__` envelope (`__OBJECT__` → `object`,
+  `__VERSION__` → `version`, `__HASH__` → `hash`, `__FORMAT__` → `format`), and re-namespaced the user-data sentinels
+  with a `__ver_*__` prefix (`__ndarray__` → `__ver_ndarray__`, `__json__` → `__ver_json__`). The `__versionable__`
+  wrapper key itself is unchanged.
+- Backwards compatibility: `load()` continues to accept the old key names from 0.1.x files for the entire 0.2.x line
+  (preferring new keys when both are present); the legacy read path will be removed in 1.0. Saved files always use the
+  new keys.
+- The warning emitted by `load()` for files missing version metadata now reads `No version found …` (was
+  `No __VERSION__ found …`).
 
 ## 0.1.0
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -15,8 +15,9 @@ migrate between formats or write tests against a lighter-weight backend than you
 | `.toml`         | `TomlBackend` | Human-editable config files          |
 | `.h5`, `.hdf5`  | `Hdf5Backend` | Large numpy arrays, lazy loading     |
 
-All backends store the same schema metadata (`__OBJECT__`, `__VERSION__`, `__HASH__`) alongside your data, so `load()`
-can validate the schema and apply migrations regardless of which backend wrote the file.
+All backends store the same schema metadata (`object`, `version`, `hash` inside the `__versionable__` envelope)
+alongside your data, so `load()` can validate the schema and apply migrations regardless of which backend wrote the
+file.
 
 ## Feature comparison
 
@@ -52,9 +53,9 @@ channels:
   - 1
   - 2
 __versionable__:
-  __OBJECT__: SensorConfig
-  __VERSION__: 1
-  __HASH__: 9d6951
+  object: SensorConfig
+  version: 1
+  hash: 9d6951
 ```
 
 Both `.yaml` and `.yml` extensions are supported.
@@ -84,9 +85,9 @@ sampleRate_Hz: 120000
 # - 1
 # - 2
 __versionable__:
-  __OBJECT__: SensorConfig
-  __VERSION__: 1
-  __HASH__: 9d6951
+  object: SensorConfig
+  version: 1
+  hash: 9d6951
 ```
 
 ## JSON
@@ -104,9 +105,11 @@ The output includes schema metadata alongside the data:
 
 ```json
 {
-  "__OBJECT__": "SensorConfig",
-  "__VERSION__": 1,
-  "__HASH__": "9d6951",
+  "__versionable__": {
+    "object": "SensorConfig",
+    "version": 1,
+    "hash": "9d6951"
+  },
   "name": "probe-A",
   "sampleRate_Hz": 120000,
   "channels": [0, 1, 2]
@@ -132,9 +135,9 @@ sampleRate_Hz = 120000
 channels = [0, 1, 2]
 
 [__versionable__]
-__OBJECT__ = "SensorConfig"
-__VERSION__ = 1
-__HASH__ = "9d6951"
+object = "SensorConfig"
+version = 1
+hash = "9d6951"
 ```
 
 Fields come first deliberately — if a user opens the file to hand-edit a value, the data is right at the top and the
@@ -177,14 +180,14 @@ The saved TOML looks like:
 name = "worker"
 
 [__versionable__]
-__OBJECT__ = "WorkerConfig"
-__VERSION__ = 1
-__HASH__ = "8bdfa7"
+object = "WorkerConfig"
+version = 1
+hash = "8bdfa7"
 
 [retry]
-__OBJECT__ = "RetryPolicy"
-__VERSION__ = 1
-__HASH__ = "f907a9"
+object = "RetryPolicy"
+version = 1
+hash = "f907a9"
 retries = 3
 backoff_s = 1.0
 ```
@@ -204,9 +207,9 @@ sampleRate_Hz = 120000
 # channels = [0, 1, 2]
 
 [__versionable__]
-__OBJECT__ = "SensorConfig"
-__VERSION__ = 1
-__HASH__ = "9d6951"
+object = "SensorConfig"
+version = 1
+hash = "9d6951"
 ```
 
 ## HDF5
@@ -271,9 +274,9 @@ Every field maps to a native HDF5 construct:
 | `Enum`                                                | Attribute (stores `.value`)                    |
 | Converted types (datetime, Path, etc.)                | Attribute (converter output)                   |
 
-Metadata (`__OBJECT__`, `__VERSION__`, `__HASH__`) is stored in a `__versionable__` child group at the root and inside
-each nested Versionable subgroup. This distinguishes Versionable groups from plain collection groups. `__FORMAT__` is
-reserved in this group for future versionable versioning.
+Metadata (`object`, `version`, `hash`) is stored as attributes on a `__versionable__` child group at the root and inside
+each nested Versionable subgroup. This distinguishes Versionable groups from plain collection groups. The `format`
+attribute is reserved in this group for future versionable file format versioning.
 
 Files are readable with h5dump, HDFView, MATLAB, or any HDF5-compatible tool. Reconstructing exact Python types (e.g.,
 distinguishing `list[float]` from `np.ndarray`) requires the class's type annotations.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -185,12 +185,16 @@ version = 1
 hash = "8bdfa7"
 
 [retry]
+retries = 3
+backoff_s = 1.0
+
+[retry.__versionable__]
 object = "RetryPolicy"
 version = 1
 hash = "f907a9"
-retries = 3
-backoff_s = 1.0
 ```
+
+Each nested `Versionable` carries its own `__versionable__` sub-table — the same shape as the root envelope.
 
 ### Comment-Out Defaults
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,9 +72,9 @@ The YAML file on disk looks like:
 name: experiment-A
 value: 9.81
 __versionable__:
-  __OBJECT__: MyConfig
-  __VERSION__: 1
-  __HASH__: 4b7866
+  object: MyConfig
+  version: 1
+  hash: 4b7866
 ```
 
 Now you rename the field without updating the hash:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -10,8 +10,8 @@ break all existing files on every schema change.
 2. Recompute `hash` (via `MyClass.hash()`)
 3. Add a `Migrate` inner class that tells **`versionable`** how to transform old data into the new shape
 
-When `load()` reads a file, it checks `__VERSION__` in the metadata. If it's behind the current version, migrations are
-applied in order — v1 → v2 → v3 — before the object is constructed.
+When `load()` reads a file, it checks `version` in the `__versionable__` metadata envelope. If it's behind the current
+version, migrations are applied in order — v1 → v2 → v3 — before the object is constructed.
 
 ## Declarative Operations
 
@@ -38,9 +38,9 @@ title: batch-processor
 debug: false
 retries: 5
 __versionable__:
-  __OBJECT__: WorkerConfig
-  __VERSION__: 1
-  __HASH__: 5556c8
+  object: WorkerConfig
+  version: 1
+  hash: 5556c8
 ```
 
 ### Rename a Field
@@ -222,8 +222,8 @@ v1 = Migration().derive("timestamps", from_="raw_data", via=lambda d: d[:, 0]).d
 
 ## Renaming a Class
 
-When you rename a `Versionable` class, existing files on disk still contain the old name in their `__OBJECT__` metadata.
-Use `old_names` to register the old name(s) so those files can still be loaded:
+When you rename a `Versionable` class, existing files on disk still contain the old name as the `object` attribute in
+their `__versionable__` metadata. Use `old_names` to register the old name(s) so those files can still be loaded:
 
 ```python
 # Was previously called "SensorReading"
@@ -237,8 +237,8 @@ class Measurement(
 
 With this declaration:
 
-- New files are saved with `__OBJECT__: "Measurement"`
-- Files saved with `__OBJECT__: "SensorReading"` can still be loaded via `loadDynamic()`
+- New files are saved with `object: "Measurement"`
+- Files saved with `object: "SensorReading"` can still be loaded via `loadDynamic()`
 - Multiple old names are supported: `old_names=["SensorReading", "DataPoint"]`
 
 If another class already owns one of the old names, class definition raises `VersionableError` instead of silently

--- a/docs/plans/envelope-keys.md
+++ b/docs/plans/envelope-keys.md
@@ -3,7 +3,7 @@
 # Envelope Keys: Drop Redundant Dunders
 
 - **Created:** 2026-04-27
-- **Last updated:** 2026-04-29
+- **Last updated:** 2026-05-01
 - **Status:** Implemented
 - **Branch:** `feature/envelope-keys`
 - **Targets release:** 0.2.0
@@ -113,6 +113,29 @@ Write only new keys. No flag, no opt-out — old-key writes don't exist after th
 Read-both stays through the 0.2.x line. Drop old-key reads at 1.0, with a migration tool (or instructions to
 re-save) for any straggler 0.1.x files. Tracked in `docs/plans/envelope-keys.md` (this file) under
 [Drop schedule](#drop-schedule).
+
+## Nested Versionable layout
+
+Nested `Versionable` values get their own `__versionable__` envelope, just like the root. Before this change,
+nested objects had envelope keys flat alongside data fields:
+
+```json
+"point": {"object": "Inner", "version": 1, "hash": "...", "x": 1.0, "y": 2.0}
+```
+
+After:
+
+```json
+"point": {"__versionable__": {"object": "Inner", "version": 1, "hash": "..."}, "x": 1.0, "y": 2.0}
+```
+
+Same shape across JSON, YAML, TOML, and HDF5. HDF5 already used a `__versionable__` child group at every level
+— this change brings the text backends in line. For TOML the `toml` library emits this as a
+`[parent.__versionable__]` sub-table, which is the canonical TOML form for the equivalent payload.
+
+The deserialize path is structurally indifferent to envelope key location — `_deserializeVersionable` iterates
+dataclass fields and pulls values; envelope keys (whether flat or wrapped) are skipped because they aren't
+fields. So no read-side back-compat code is needed for the wrap.
 
 ## File-format examples (after the rename)
 

--- a/docs/plans/envelope-keys.md
+++ b/docs/plans/envelope-keys.md
@@ -1,0 +1,248 @@
+[//]: # (vim: set ft=markdown:)
+
+# Envelope Keys: Drop Redundant Dunders
+
+- **Created:** 2026-04-27
+- **Last updated:** 2026-04-27
+- **Status:** Proposed
+- **Branch:** `feature/envelope-keys`
+- **Targets release:** 0.2.0
+
+## Problem
+
+Today's metadata envelope uses SCREAMING_DUNDER keys *inside* a wrapper that is itself already namespaced as
+`__versionable__`. The result reads like an unfriendly internal:
+
+```yaml
+__versionable__:
+  __OBJECT__: MyConfig
+  __VERSION__: 1
+  __HASH__: 4b7866
+name: probe-A
+```
+
+The wrapper is doing namespace work; the inner dunders are noise. They make hand-edited config files harder to scan
+and don't match the lowercase / snake_case convention used elsewhere (YAML/TOML idioms, Python kwargs like
+`skip_defaults`, `old_names`).
+
+A separate but related cleanup: the user-data sentinels (`__ndarray__`, `__json__`, `__lazy__`) are *not* inside the
+wrapper — they live in user values and need to remain visually distinct. But their bare names risk colliding with
+anything a user might put in a dict. Re-namespacing them to `__ver_*__` keeps the dunder visibility and adds clear
+package ownership.
+
+## Goal
+
+A single PR, lands in 0.2.0:
+
+1. **Inside `__versionable__`, drop the dunders.** Lowercase for single words, snake_case for multi-word.
+2. **Outside `__versionable__`, keep dunders but add a `__ver_*__` prefix** so user-data sentinels are
+   unambiguously package-owned.
+3. **Read both old and new keys** for one release cycle so 0.1.x files still load. Always write only new keys.
+
+## Renames
+
+### Inside `__versionable__` (drop dunders)
+
+| Old              | New           | Notes                                                  |
+| ---------------- | ------------- | ------------------------------------------------------ |
+| `__OBJECT__`     | `object`      | Class serialization name                               |
+| `__VERSION__`    | `version`     | Schema version                                         |
+| `__HASH__`       | `hash`        | 6-char schema hash                                     |
+| `__FORMAT__`     | `format`      | Reserved for future versionable file format versioning |
+| `__FORMAT_BE__`  | `format_be`   | Reserved for future per-backend format versioning      |
+| `__SHARED_REFS__`| `shared_refs` | PR 2 (0.3.0) — opt-in shared-reference encoding flag   |
+
+`__FORMAT__`, `__FORMAT_BE__`, `__SHARED_REFS__` are **never written today**. The first two are reserved
+constants in error messages; the third lives in the PR 2 plan doc. Renaming them is documentation-only for now —
+no files in the wild contain them.
+
+### User-data sentinels (keep dunders, add `__ver_*__` prefix)
+
+| Old           | New                | Notes                                                |
+| ------------- | ------------------ | ---------------------------------------------------- |
+| `__ndarray__` | `__ver_ndarray__`  | Marks a JSON/TOML/YAML dict as an inline numpy array |
+| `__json__`    | `__ver_json__`     | YAML/TOML wrapper for values without native encoding |
+| `__lazy__`    | `__ver_lazy__`     | In-memory only (never on disk) — internal HDF5 reader marker |
+
+Plus PR 2 sentinels (planned for 0.3.0, not implemented in this PR but spec'd in
+`docs/plans/reference-handling.md`):
+
+| Planned (old) | Planned (new)  | Notes                                                |
+| ------------- | -------------- | ---------------------------------------------------- |
+| `__ID__`      | `__ver_id__`   | Identity marker for shared references                |
+| `__REF__`     | `__ver_ref__`  | Reference to an earlier `__ver_id__`                 |
+
+### Stays as-is
+
+- `__versionable__` (the wrapper key itself) — it *is* the namespace marker; the dunder is doing real work.
+- Internal meta-dict keys passed between `_api.load` and backends (`__OBJECT__`, `__VERSION__`, `__HASH__` in the
+  `tuple[fields, meta]` returned by `Backend.load`). Optional: rename these too for symmetry — see
+  [Open questions](#open-questions). Default: leave alone, change is local to file format.
+
+## Backwards compatibility
+
+### Read
+
+`Backend.load()` accepts both old and new keys, preferring new when both are present (no real file should have
+both). Concretely, in each backend's `load`:
+
+```python
+metaTable = data.pop("__versionable__", {})
+meta = {
+    "__OBJECT__": metaTable.get("object", metaTable.get("__OBJECT__", "")),
+    "__VERSION__": metaTable.get("version", metaTable.get("__VERSION__")),
+    "__HASH__": metaTable.get("hash", metaTable.get("__HASH__", "")),
+}
+fileFormat = metaTable.get("format", metaTable.get("__FORMAT__"))
+```
+
+For user-data sentinels (`__ndarray__`, `__json__`), the converters / unwrappers accept both forms:
+
+```python
+if isinstance(value, dict):
+    if "__ver_ndarray__" in value or "__ndarray__" in value:
+        ...
+```
+
+### Write
+
+Write only new keys. No flag, no opt-out — old-key writes don't exist after this PR.
+
+### Deprecation timing
+
+Read-both stays through the 0.2.x line. Drop old-key reads at 1.0, with a migration tool (or instructions to
+re-save) for any straggler 0.1.x files. Tracked in `docs/plans/envelope-keys.md` (this file) under
+[Drop schedule](#drop-schedule).
+
+## File-format examples (after the rename)
+
+### JSON
+
+```json
+{
+  "__versionable__": {
+    "object": "MyConfig",
+    "version": 1,
+    "hash": "4b7866"
+  },
+  "name": "probe-A",
+  "data": {
+    "__ver_ndarray__": true,
+    "dtype": "float64",
+    "shape": [3],
+    "data": "<base64>"
+  }
+}
+```
+
+### YAML
+
+```yaml
+__versionable__:
+  object: MyConfig
+  version: 1
+  hash: 4b7866
+name: probe-A
+```
+
+### TOML
+
+```toml
+[__versionable__]
+object = "MyConfig"
+version = 1
+hash = "4b7866"
+
+name = "probe-A"
+```
+
+### HDF5
+
+```text
+/__versionable__/
+  attrs:
+    object = "MyConfig"
+    version = 1
+    hash = "4b7866"
+attrs (root):
+  name = "probe-A"
+```
+
+## Touchpoints
+
+### Source (8 files, ~70 sites)
+
+| File                          | What                                                        |
+| ----------------------------- | ----------------------------------------------------------- |
+| `_json_backend.py`            | save: write new keys; load: read both                       |
+| `_yaml_backend.py`            | save: write new keys; load: read both                       |
+| `_toml_backend.py`            | save: write new keys; load: read both                       |
+| `_hdf5_backend.py`            | save: write new attrs on `__versionable__` group; load: read both |
+| `_hdf5_session.py`            | resume: read both; create: write new                        |
+| `_types.py`                   | `__ndarray__` ↔ `__ver_ndarray__`; `__lazy__` ↔ `__ver_lazy__` |
+| `_yaml_backend.py`, `_toml_backend.py` | `__json__` ↔ `__ver_json__` (wrappers)             |
+| `_backend.py`, `_api.py`      | Comments / strings if any reference the old names           |
+
+### Tests
+
+Per-backend test fixtures (`test_json_backend.py`, `test_yaml_backend.py`, `test_toml_backend.py`,
+`test_hdf5_backend.py`) and golden-file tests that hardcode the dunder strings. Plus new back-compat tests:
+
+- For each backend: an old-format file (hand-rolled with `__OBJECT__` etc.) loads correctly.
+- For each backend: an old-format file with `__ndarray__` / `__json__` loads correctly.
+- Mixed old + new on the same file: prefer new (or error — see [Open questions](#open-questions)).
+
+### Docs (in `docs/`)
+
+- `reference.md` — "Reserved Keys" table (rewrite).
+- `AGENT.md`, `getting-started.md`, `migrations.md`, `backends.md`, `types.md`, `skills.md` — any prose mentioning
+  the dunders.
+- `plans/reference-handling.md` — update the PR 2 spec to use `shared_refs` and `__ver_id__`/`__ver_ref__`. (PR
+  #25, which ships the cycle-detection part of that plan, also lands the new key names in its plan-doc copy.)
+- `plans/native-hdf5-storage.md`, `plans/save-as-you-go-hdf5.md` — historical plans, mention the dunders. Update
+  for accuracy or annotate with a "superseded by …" note.
+
+### Examples
+
+- `examples/comment_defaults.py` — verify output still looks right.
+
+## Acceptance
+
+- All existing tests pass after touchups.
+- New back-compat tests cover at least one old-format file per backend, plus old-format ndarray/json sentinels.
+- `pixi run cleanup && pixi run pytest` green.
+- `docs/reference.md` reserved-keys table reflects the new shape.
+- `CHANGELOG.md` 0.2.0 entry mentions the rename and the back-compat read window.
+- `docs/plans/reference-handling.md` updated to use `shared_refs`, `__ver_id__`, `__ver_ref__` so PR 2 starts on
+  the right names.
+
+## Drop schedule
+
+| Release | Behavior                                                                     |
+| ------- | ---------------------------------------------------------------------------- |
+| 0.2.0   | Read both old and new. Write only new.                                       |
+| 0.2.x   | Same as 0.2.0.                                                               |
+| 1.0     | Drop old-key read support. Provide migration: `versionable migrate <file>` or "load and re-save". |
+
+## Risk
+
+Low–medium. Mechanical rename, but file format change. The mitigations:
+
+- Read-both back-compat means existing 0.1.x files keep working.
+- The user-data sentinel renames (`__ver_ndarray__` etc.) are the only place where a careful test suite per
+  backend is needed — converters use these as type discriminators inside arbitrary dicts.
+
+## Open questions
+
+1. **Internal meta-dict keys.** `Backend.load()` returns `(fields, meta)` where `meta` uses `__OBJECT__` /
+   `__VERSION__` / `__HASH__` as dict keys (matching the file format keys it's translating from). After the
+   rename, should this internal contract switch to `object` / `version` / `hash`? Default: yes, for symmetry —
+   the contract is internal, no external callers, and the save-side already uses lowercase (`metaDict = {"name":
+   ..., "version": ..., "hash": ...}`).
+2. **Mixed old + new in the same file.** A handcrafted file could in theory have both. Read prefers new; should
+   it warn? Default: no — silent prefer-new keeps the load path simple. Collisions in real files won't happen.
+3. **`__ver_lazy__` is internal-only.** It's never written to disk; it's a marker on in-memory dicts during the
+   HDF5 lazy-read path. The rename is purely cosmetic. Confirm no external code depends on the name.
+4. **Migration tool at 1.0.** Out of scope for this PR but worth filing a tracking issue: a `versionable
+   migrate <path>` CLI that rewrites old-key files in place. Or just document "load and re-save" as the
+   migration path.

--- a/docs/plans/envelope-keys.md
+++ b/docs/plans/envelope-keys.md
@@ -3,8 +3,8 @@
 # Envelope Keys: Drop Redundant Dunders
 
 - **Created:** 2026-04-27
-- **Last updated:** 2026-04-27
-- **Status:** Proposed
+- **Last updated:** 2026-04-29
+- **Status:** Implemented
 - **Branch:** `feature/envelope-keys`
 - **Targets release:** 0.2.0
 

--- a/docs/plans/native-hdf5-storage.md
+++ b/docs/plans/native-hdf5-storage.md
@@ -1,5 +1,10 @@
 # Native HDF5 Storage (Eliminate JSON)
 
+> **Historical plan — implemented.** Envelope key names in this document
+> (`__OBJECT__`, `__VERSION__`, `__HASH__`, `__ndarray__`) were renamed in
+> 0.2.0; see `docs/plans/envelope-keys.md`. Current names are `object`,
+> `version`, `hash`, `__ver_ndarray__`.
+
 ## Problem
 
 The HDF5 backend previously bundled all non-array fields into a single `__scalars__` JSON attribute:

--- a/docs/plans/reference-handling.md
+++ b/docs/plans/reference-handling.md
@@ -31,8 +31,8 @@ Two-step rollout, two PRs:
    `CircularReferenceError` carrying the field path. Strict additive change; no file format change; no public
    API change beyond a new exception class.
 2. **PR 2 — Shared references (ships in 0.3.0).** Opt-in, per-class, lossless preservation of shared instances
-   (and therefore cycles, for non-frozen classes). Each backend uses its idiomatic primitive: `__ID__` /
-   `__REF__` envelopes for JSON/TOML, native YAML anchors, HDF5 hard links.
+   (and therefore cycles, for non-frozen classes). Each backend uses its idiomatic primitive: `__ver_id__` /
+   `__ver_ref__` envelopes for JSON/TOML, native YAML anchors, HDF5 hard links.
 
 PR 1 is a strict correctness improvement that any release should ship. It also establishes the threading and
 error machinery that PR 2 builds on.
@@ -211,27 +211,27 @@ flows in.
 
 ### File format — JSON / TOML
 
-A first-occurrence object gets an `__ID__` field; subsequent occurrences are replaced by a one-key envelope:
+A first-occurrence object gets an `__ver_id__` field; subsequent occurrences are replaced by a one-key envelope:
 
 ```json
 {
-  "__versionable__": {"__OBJECT__": "Node", "__VERSION__": 1, "__HASH__": "...", "__SHARED_REFS__": true},
-  "__ID__": "#0",
+  "__versionable__": {"object": "Node", "version": 1, "hash": "...", "shared_refs": true},
+  "__ver_id__": "#0",
   "name": "root",
   "children": [
-    {"__OBJECT__": "Node", "__VERSION__": 1, "__HASH__": "...", "__ID__": "#1", "name": "left", "children": []},
-    {"__REF__": "#1"}
+    {"object": "Node", "version": 1, "hash": "...", "__ver_id__": "#1", "name": "left", "children": []},
+    {"__ver_ref__": "#1"}
   ]
 }
 ```
 
 Notes:
 
-- `__SHARED_REFS__: true` on the root metadata declares the file uses ref semantics — readers can fast-path
+- `shared_refs: true` on the root metadata declares the file uses ref semantics — readers can fast-path
   files without it (no two-pass needed).
 - IDs are local to the file (`"#0"`, `"#1"`, …) and assigned in pre-order traversal. They're opaque strings, not
   numbers, so users don't read meaning into them.
-- Refs to the root use `{"__REF__": "#0"}` like any other.
+- Refs to the root use `{"__ver_ref__": "#0"}` like any other.
 - Non-`Versionable` shared values (numpy arrays, dataclasses-but-not-Versionable, dicts) are still duplicated.
   This is a deliberate scope limit — Versionable owns identity tracking only for its own instances.
 
@@ -242,34 +242,34 @@ Python object is encountered twice during dumping. To get this for free we need 
 intermediate representation**: when serializing a `Versionable` we've already seen, emit the *same* dict
 object (not a fresh copy with `__REF__`).
 
-This makes YAML files cleaner than JSON's `__REF__` envelopes:
+This makes YAML files cleaner than JSON's `__ver_ref__` envelopes:
 
 ```yaml
 __versionable__:
-  __OBJECT__: Node
-  __VERSION__: 1
-  __HASH__: "..."
-  __SHARED_REFS__: true
-__ID__: "#0"
+  object: Node
+  version: 1
+  hash: "..."
+  shared_refs: true
+__ver_id__: "#0"
 name: root
 children:
   - &id001
-    __OBJECT__: Node
-    __ID__: "#1"
+    object: Node
+    __ver_id__: "#1"
     name: left
     children: []
   - *id001
 ```
 
 On load, PyYAML restores identity automatically — `parent["children"][0] is parent["children"][1]` is `True`.
-We then walk the loaded dict and `__REF__`-resolution becomes mostly a no-op; we just need to map dict
+We then walk the loaded dict and `__ver_ref__`-resolution becomes mostly a no-op; we just need to map dict
 identity to instance identity.
 
 ### File format — TOML
 
 TOML has no anchor concept and no inline references in the spec. Use the JSON envelope approach
-(`__ID__` / `__REF__`). TOML's table syntax handles this fine — a `__REF__` table is just a one-key inline
-table.
+(`__ver_id__` / `__ver_ref__`). TOML's table syntax handles this fine — a `__ver_ref__` table is just a
+one-key inline table.
 
 ### File format — HDF5
 
@@ -277,7 +277,7 @@ HDF5 has hard links and soft links natively. Use **hard links**:
 
 ```text
 /__versionable__/
-/__versionable__/__SHARED_REFS__ (attr) = True
+/__versionable__/shared_refs (attr) = True
 /name (attr) = "root"
 /children/
 /children/0/                    ← first occurrence: full subgroup
@@ -302,13 +302,13 @@ three need synthetic IDs.
 
 For JSON/TOML (and YAML pre-identity-preservation), refs need resolution after the dict is parsed. The flow:
 
-1. **Parse pass** — backend produces a raw dict tree with `__REF__` markers at the leaves where shared.
-2. **Index pass** — walk the tree; collect every `__ID__` → its dict.
+1. **Parse pass** — backend produces a raw dict tree with `__ver_ref__` markers at the leaves where shared.
+2. **Index pass** — walk the tree; collect every `__ver_id__` → its dict.
 3. **Construct pass** — for each unique ID, build a *shell* `Versionable` instance:
    - Mutable classes (default): construct with placeholder values for ref-typed fields, fill via `setattr` later.
    - Frozen classes: collect into a topological build order. If the graph has a cycle and the class is frozen,
      raise `BackendError("Cannot load cycle into frozen class X")`.
-4. **Resolve pass** — walk the tree replacing `__REF__: "#1"` with the constructed instance for `"#1"`.
+4. **Resolve pass** — walk the tree replacing `__ver_ref__: "#1"` with the constructed instance for `"#1"`.
 5. **Post-init pass** — call `__post_init__` (skipped during shell construction) on each instance in topological
    order. For cycles, run `__post_init__` last and document the caveat.
 
@@ -324,17 +324,17 @@ cycles, `__post_init__` may observe `self` in fields before construction has ful
 | `_base.py::__init_subclass__` | Accept `shared_refs: bool = False`; store on `_InternalMeta`. |
 | `_base.py::VersionableMetadata` | Add `sharedRefs: bool` field. |
 | `_types.py::serialize` | When root `shared_refs=True`, switch to ID-tracking serializer. |
-| `_types.py` | New `_serializeWithRefs(obj)` that maintains `id(obj) → assignedId` and emits `__ID__`/`__REF__`. |
+| `_types.py` | New `_serializeWithRefs(obj)` that maintains `id(obj) → assignedId` and emits `__ver_id__`/`__ver_ref__`. |
 | `_types.py` | New `_deserializeWithRefs(data, cls)` that runs the four-pass load. |
 | `_api.py::save` | Accept `sharedRefs: bool | None = None`; resolve override vs. class flag. |
-| `_api.py::load` | Detect `__SHARED_REFS__: True` in metadata; route to ref-aware path. |
+| `_api.py::load` | Detect `shared_refs: True` in metadata; route to ref-aware path. |
 | `_json_backend.py` | No format-specific changes — uses generic `serialize`/`deserialize`. |
 | `_yaml_backend.py` | Preserve dict identity in the intermediate IR so PyYAML emits anchors. Document the trick. |
 | `_toml_backend.py` | No format-specific changes. |
 | `_hdf5_backend.py::_writeFields` | When in shared-refs mode, track `id(obj) → group_path`; emit hard links. |
 | `_hdf5_backend.py::_readFields` | Track `h5py.Group.id` → Python instance; recurse into hard-linked groups only on first sight. |
 | `errors.py` | New `FrozenCycleError(BackendError)` for cycles into frozen classes. |
-| `_migration.py` | Resolve refs *before* migrations run. Migrations see Python objects, never `__REF__` dicts. Document. |
+| `_migration.py` | Resolve refs *before* migrations run. Migrations see Python objects, never `__ver_ref__` dicts. Document. |
 | `__init__.py` | Re-export new symbols. |
 
 ### Tests (`tests/test_shared_refs.py`)
@@ -357,22 +357,22 @@ Plus identity assertions on every loaded graph: `loaded.left is loaded.right`.
 
 Plus migration tests: a v1 file with shared refs migrates to v2 with the shared structure preserved.
 
-Plus a backwards-compat test: a 0.2.x file (no `__SHARED_REFS__` marker) loads under a 0.3.0 reader.
+Plus a backwards-compat test: a 0.2.x file (no `shared_refs` marker) loads under a 0.3.0 reader.
 
 ### Migration impact
 
 Refs are resolved before migrations run, so migration code stays simple. Document this for users writing
 imperative migrations: their `MigrationContext` sees a real Python object graph (with cycles intact), not
-`__REF__` dicts. Existing migrations are unaffected because the resolution pass happens transparently.
+`__ver_ref__` dicts. Existing migrations are unaffected because the resolution pass happens transparently.
 
 ### Backwards compatibility
 
-- A 0.2.x file (no `__SHARED_REFS__: true` in metadata) reads under 0.3.0 with the existing code path —
+- A 0.2.x file (no `shared_refs: true` in metadata) reads under 0.3.0 with the existing code path —
   no two-pass load, no perf hit. Detection is a single attribute check.
-- A 0.3.0 file *with* `__SHARED_REFS__: true` cannot be read by 0.2.x. This is fine — the feature is opt-in
+- A 0.3.0 file *with* `shared_refs: true` cannot be read by 0.2.x. This is fine — the feature is opt-in
   per class, so users who don't enable it keep producing 0.2.x-readable files. Document the forward-compat
   break clearly.
-- `__SHARED_REFS__: false` is never written (omission means false).
+- `shared_refs: false` is never written (omission means false).
 
 ### Risk
 
@@ -386,6 +386,8 @@ opt-in flag specifically so users who don't want the complexity don't pay for it
 - Identity assertions hold on every loaded graph.
 - Documentation covers the opt-in flag, `__post_init__` ordering, frozen-class limitation, and forward-compat
   break.
+- Reserved-keys docs in `docs/reference.md` list `__ver_id__`, `__ver_ref__`, and the `shared_refs` envelope
+  flag as reserved.
 - `pixi run cleanup && pixi run pytest` green.
 
 ---
@@ -395,7 +397,7 @@ opt-in flag specifically so users who don't want the complexity don't pay for it
 - **Sharing of non-Versionable values.** A numpy array referenced twice still duplicates. HDF5 users who
   want to dedupe arrays can use `Hdf5FieldInfo` / hard links manually. Versionable doesn't track identity for
   primitives, dicts, or arrays.
-- **Cross-file references.** Refs are local to one file. No `__REF__: "other_file.json#1"` plans.
+- **Cross-file references.** Refs are local to one file. No `__ver_ref__: "other_file.json#1"` plans.
 - **External graph databases.** This isn't a graph DB — it's a serializer that doesn't break when graphs
   show up.
 - **Reference-aware diffing.** Comparing two saved graphs by structure rather than text — interesting, not
@@ -413,7 +415,7 @@ opt-in flag specifically so users who don't want the complexity don't pay for it
    `__post_init__` on shared_refs classes? Lean toward "run after, document the caveat" but want a concrete
    user case before committing.
 4. **Should the sidecar-table layout (`__objects__: {id: {...}}, __root__: ref`) be considered as an
-   alternative to inline `__ID__`?** It's cleaner to migrate but worse for hand-editing. Inline matches
+   alternative to inline `__ver_id__`?** It's cleaner to migrate but worse for hand-editing. Inline matches
    YAML's anchor model. Tentative: inline.
 5. **Exposing `sharedRefs` on `VersionableMetadata`** — should it be public introspection? Probably yes,
    to mirror `skipDefaults` / `unknown`.

--- a/docs/plans/save-as-you-go-hdf5.md
+++ b/docs/plans/save-as-you-go-hdf5.md
@@ -1,5 +1,9 @@
 # Save-As-You-Go for HDF5
 
+> **Historical plan — implemented.** Envelope key names in this document
+> (`__OBJECT__`, `__VERSION__`, `__HASH__`) were renamed in 0.2.0; see
+> `docs/plans/envelope-keys.md`. Current names are `object`, `version`, `hash`.
+
 ## Problem
 
 When collecting data incrementally (e.g., appending traces from a DAQ, accumulating simulation results), users

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -123,18 +123,31 @@ class MyConfig(Versionable, version=1, hash="4b7866"):
 
 ## Reserved Keys
 
-The following dunder keys are used internally by **`versionable`** and must not be used as field names or as keys in
-user-provided dict values:
+The following keys are used internally by **`versionable`** and must not be used as field names or as keys in
+user-provided dict values.
 
-| Key               | Purpose                                                   |
-| ----------------- | --------------------------------------------------------- |
-| `__ndarray__`     | Marks a dict as a serialized numpy array (JSON/YAML/TOML) |
-| `__json__`        | YAML-only wrapper for values with no native YAML encoding |
-| `__versionable__` | Versionable metadata envelope                             |
-| `__OBJECT__`      | Serialization class name (stored in metadata)             |
-| `__VERSION__`     | Schema version (stored in metadata)                       |
-| `__HASH__`        | Schema hash (stored in metadata)                          |
-| `__FORMAT__`      | Reserved for future versionable versioning                |
-| `__FORMAT_BE__`   | Reserved for future backend versioning                    |
+The `__versionable__` envelope at the root of every saved file holds the schema metadata (no dunders inside — the
+wrapper key is the namespace marker):
+
+| Key       | Purpose                                                |
+| --------- | ------------------------------------------------------ |
+| `object`  | Serialization class name (stored in `__versionable__`) |
+| `version` | Schema version (stored in `__versionable__`)           |
+| `hash`    | Schema hash (stored in `__versionable__`)              |
+| `format`  | Reserved for future versionable file format versioning |
+
+User-data sentinels (live alongside user values; the `__ver_*__` prefix marks them as package-owned):
+
+| Key               | Purpose                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `__versionable__` | Versionable metadata envelope (wrapper key — namespace marker) |
+| `__ver_ndarray__` | Marks a dict as a serialized numpy array (JSON/YAML/TOML)      |
+| `__ver_json__`    | YAML/TOML wrapper for values with no native encoding           |
 
 > ⚠️ **Warning:** Using any of these as a field name or dict key may cause incorrect serialization or deserialization.
+
+### Compatibility with 0.1.x files
+
+Files written by versionable 0.1.x used dunder forms inside the envelope (`__OBJECT__`, `__VERSION__`, `__HASH__`,
+`__FORMAT__`) and bare sentinels (`__ndarray__`, `__json__`). Throughout the 0.2.x line, `load()` accepts both the old
+and new keys, preferring the new ones. Saved files always use the new keys. The legacy read path will be removed in 1.0.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -93,7 +93,7 @@ loaded = versionable.load(MyClass, "data.h5", preload=["big"])   # Eager-load sp
 loaded = versionable.load(MyClass, "data.h5", preload="*")       # Eager-load all arrays
 loaded = versionable.load(MyClass, "data.h5", metadataOnly=True) # Skip arrays entirely
 
-obj = versionable.loadDynamic("file.yaml")                      # Type from __OBJECT__ metadata
+obj = versionable.loadDynamic("file.yaml")                      # Type from `object` metadata
 
 # Introspection
 meta = versionable.metadata(MyClass)  # VersionableMetadata(version, hash, name, fields, ...)
@@ -133,8 +133,9 @@ class SensorConfig(
 **Serialized fields:** annotated, non-private (no `_` prefix), non-`ClassVar`. Private fields, unannotated attributes,
 and `ClassVar` are excluded.
 
-**Reserved metadata keys (cannot be field names):** `__OBJECT__`, `__VERSION__`, `__HASH__`, `__versionable__`,
-`__ndarray__`, `__json__`.
+**Reserved metadata keys (cannot be field names):** `__versionable__` (envelope wrapper), `__ver_ndarray__`,
+`__ver_json__`. Inside the `__versionable__` envelope: `object`, `version`, `hash`, `format`. The 0.1.x dunder forms
+(`__OBJECT__`, `__ndarray__`, `__json__`, etc.) are still accepted on read for back-compat.
 
 ### Type System
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -83,7 +83,7 @@ class Shape(Versionable, version=1, hash="..."):
   integer-keyed datasets; `dict[str, np.ndarray]` becomes a group of named datasets. Both support per-element lazy
   loading. See [Backends](backends.md).
 - **JSON / TOML:** Stored as base64-compressed npz blobs.
-- **YAML:** Stored as a `__json__` wrapper containing the base64-compressed npz blob as a JSON string.
+- **YAML:** Stored as a `__ver_json__` wrapper containing the base64-compressed npz blob as a JSON string.
 
 ## Custom Converters
 

--- a/examples/comment_defaults.py
+++ b/examples/comment_defaults.py
@@ -60,23 +60,23 @@ if __name__ == "__main__":
 # # debug = false
 #
 # [__versionable__]
-# __OBJECT__ = "ServerConfig"
-# __VERSION__ = 1
-# __HASH__ = ""
+# object = "ServerConfig"
+# version = 1
+# hash = ""
 #
 # [database]
-# __OBJECT__ = "DatabaseConfig"
-# __VERSION__ = 1
-# __HASH__ = ""
+# object = "DatabaseConfig"
+# version = 1
+# hash = ""
 # # host = "localhost"
 # port = 3306
 # # maxConnections = 10
 # # timeoutSec = 30.0
 #
 # [logging]
-# __OBJECT__ = "LoggingConfig"
-# __VERSION__ = 1
-# __HASH__ = ""
+# object = "LoggingConfig"
+# version = 1
+# hash = ""
 # # level = "INFO"
 # # filePath = "/var/log/app.log"
 # # rotateAfterMB = 100
@@ -87,21 +87,21 @@ if __name__ == "__main__":
 # # name: my-server
 # # debug: false
 # database:
-#   __OBJECT__: DatabaseConfig
-#   __VERSION__: 1
-#   __HASH__: ''
+#   object: DatabaseConfig
+#   version: 1
+#   hash: ''
 #   host: localhost
 #   port: 3306
 #   maxConnections: 10
 #   timeoutSec: 30.0
 # logging:
-#   __OBJECT__: LoggingConfig
-#   __VERSION__: 1
-#   __HASH__: ''
+#   object: LoggingConfig
+#   version: 1
+#   hash: ''
 # #   level: INFO
 # #   filePath: /var/log/app.log
 # #   rotateAfterMB: 100
 # __versionable__:
-#   __OBJECT__: ServerConfig
-#   __VERSION__: 1
-#   __HASH__: ''
+#   object: ServerConfig
+#   version: 1
+#   hash: ''

--- a/examples/comment_defaults.py
+++ b/examples/comment_defaults.py
@@ -65,21 +65,25 @@ if __name__ == "__main__":
 # hash = ""
 #
 # [database]
-# object = "DatabaseConfig"
-# version = 1
-# hash = ""
 # # host = "localhost"
 # port = 3306
 # # maxConnections = 10
 # # timeoutSec = 30.0
 #
 # [logging]
-# object = "LoggingConfig"
-# version = 1
-# hash = ""
 # # level = "INFO"
 # # filePath = "/var/log/app.log"
 # # rotateAfterMB = 100
+#
+# [database.__versionable__]
+# object = "DatabaseConfig"
+# version = 1
+# hash = ""
+#
+# [logging.__versionable__]
+# object = "LoggingConfig"
+# version = 1
+# hash = ""
 #
 #
 # Output YAML file:
@@ -87,17 +91,19 @@ if __name__ == "__main__":
 # # name: my-server
 # # debug: false
 # database:
-#   object: DatabaseConfig
-#   version: 1
-#   hash: ''
+#   __versionable__:
+#     object: DatabaseConfig
+#     version: 1
+#     hash: ''
 #   host: localhost
 #   port: 3306
 #   maxConnections: 10
 #   timeoutSec: 30.0
 # logging:
-#   object: LoggingConfig
-#   version: 1
-#   hash: ''
+#   __versionable__:
+#     object: LoggingConfig
+#     version: 1
+#     hash: ''
 # #   level: INFO
 # #   filePath: /var/log/app.log
 # #   rotateAfterMB: 100

--- a/src/versionable/_api.py
+++ b/src/versionable/_api.py
@@ -104,7 +104,7 @@ def load[T: Versionable](
         preload: Array field names to eagerly load, or ``'*'`` for all.
         metadataOnly: If True, array fields raise ``ArrayNotLoadedError``.
         upgradeInPlace: If True, allow file modification during migration.
-        assumeVersion: Version to assume when the file has no ``__VERSION__``
+        assumeVersion: Version to assume when the file has no ``version``
             metadata.  Defaults to the class's current version.
         validateLiterals: Whether to validate ``Literal`` type values.
             Overrides the class-level ``validate_literals`` setting.
@@ -131,14 +131,14 @@ def load[T: Versionable](
         rawFields, fileMeta = be.load(path)
 
     meta = metadata(cls)
-    fileVersion = fileMeta.get("__VERSION__")
+    fileVersion = fileMeta.get("version")
     if fileVersion is None:
         if assumeVersion is not None:
             fileVersion = assumeVersion
         else:
             fileVersion = meta.version
             logger.warning(
-                "No __VERSION__ found in '%s'. Treating as current version (%d) for %s. "
+                "No version found in '%s'. Treating as current version (%d) for %s. "
                 "If this file was written by an older version of the code, "
                 "pass assumeVersion= to load() to apply the correct migrations.",
                 path,
@@ -238,7 +238,7 @@ def loadDynamic(
     be = getBackend(path, explicit=backend)
     _rawFields, fileMeta = be.load(path)
 
-    objectName = fileMeta.get("__OBJECT__", "")
+    objectName = fileMeta.get("object", "")
     registry = registeredClasses()
 
     if objectName not in registry:

--- a/src/versionable/_backend.py
+++ b/src/versionable/_backend.py
@@ -39,8 +39,8 @@ class Backend(ABC):
 
         Returns:
             Tuple of (fields_dict, metadata_dict).
-            metadata_dict should contain ``__VERSION__``, ``__HASH__``,
-            ``__OBJECT__`` keys.
+            metadata_dict should contain ``version``, ``hash``,
+            ``object`` keys.
         """
 
 

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -13,7 +13,7 @@ Every field maps to a native HDF5 construct — no JSON anywhere:
 - Enum → attribute (stores ``.value``)
 - Converted types (datetime, Path, etc.) → attribute (converter output)
 
-Metadata (``__OBJECT__``, ``__VERSION__``, ``__HASH__``) is stored in a
+Metadata (``object``, ``version``, ``hash``) is stored as attributes on a
 ``__versionable__`` child group, distinguishing Versionable groups from
 plain collection groups.
 
@@ -75,9 +75,9 @@ class Hdf5Backend(Backend):
             with h5py.File(path, "w") as f:
                 # Write metadata into __versionable__ child group
                 metaGroup = f.create_group(_VERSIONABLE_GROUP)
-                metaGroup.attrs["__OBJECT__"] = meta["name"]
-                metaGroup.attrs["__VERSION__"] = meta["version"]
-                metaGroup.attrs["__HASH__"] = meta["hash"]
+                metaGroup.attrs["object"] = meta["name"]
+                metaGroup.attrs["version"] = meta["version"]
+                metaGroup.attrs["hash"] = meta["hash"]
 
                 # Write fields
                 _writeFields(f, fields, fieldTypes, comp, visited)
@@ -88,7 +88,7 @@ class Hdf5Backend(Backend):
         try:
             with h5py.File(path, "r") as f:
                 meta = _readMeta(f)
-                objectName = meta["__OBJECT__"]
+                objectName = meta["object"]
                 cls = _resolveClass(objectName)
                 if cls is None:
                     raise BackendError(
@@ -125,10 +125,10 @@ class Hdf5Backend(Backend):
             with h5py.File(path, "r") as f:
                 meta = _readMeta(f)
                 if cls is None:
-                    cls = _resolveClass(meta["__OBJECT__"])
+                    cls = _resolveClass(meta["object"])
                 if cls is None:
                     raise BackendError(
-                        f"Unknown Versionable type {meta['__OBJECT__']!r} in {path}. "
+                        f"Unknown Versionable type {meta['object']!r} in {path}. "
                         f"Ensure the class is imported and registered."
                     )
                 fieldTypes = _resolveFields(cls)
@@ -344,9 +344,9 @@ def _writeVersionable(
 
     # Write metadata into __versionable__ child group
     metaGroup = subgroup.create_group(_VERSIONABLE_GROUP)
-    metaGroup.attrs["__OBJECT__"] = meta.name
-    metaGroup.attrs["__VERSION__"] = meta.version
-    metaGroup.attrs["__HASH__"] = meta.hash
+    metaGroup.attrs["object"] = meta.name
+    metaGroup.attrs["version"] = meta.version
+    metaGroup.attrs["hash"] = meta.hash
 
     # Recursively write fields
     fields = {fieldName: getattr(obj, fieldName) for fieldName in fieldTypes}
@@ -363,22 +363,27 @@ def _writeVersionable(
 
 
 def _readMeta(group: h5py.Group) -> dict[str, Any]:
-    """Read metadata from the __versionable__ child group."""
+    """Read metadata from the __versionable__ child group.
+
+    Accepts both new (``object``/``version``/``hash``) and legacy
+    (``__OBJECT__``/``__VERSION__``/``__HASH__``) attribute names; new
+    keys take precedence when both are present.
+    """
     if _VERSIONABLE_GROUP in group:
         metaGroup = group[_VERSIONABLE_GROUP]
-        fileFormat = metaGroup.attrs.get("__FORMAT__")
+        fileFormat = metaGroup.attrs.get("format", metaGroup.attrs.get("__FORMAT__"))
         if fileFormat is not None:
             raise BackendError(
                 f"File uses versionable format {fileFormat!r}, but this version only supports "
                 f"format-less files. Upgrade versionable to read this file."
             )
         return {
-            "__OBJECT__": str(metaGroup.attrs.get("__OBJECT__", "")),
-            "__VERSION__": int(metaGroup.attrs.get("__VERSION__", 1)),
-            "__HASH__": str(metaGroup.attrs.get("__HASH__", "")),
+            "object": str(metaGroup.attrs.get("object", metaGroup.attrs.get("__OBJECT__", ""))),
+            "version": int(metaGroup.attrs.get("version", metaGroup.attrs.get("__VERSION__", 1))),
+            "hash": str(metaGroup.attrs.get("hash", metaGroup.attrs.get("__HASH__", ""))),
         }
     # Should not happen for well-formed files
-    return {"__OBJECT__": "", "__VERSION__": 1, "__HASH__": ""}
+    return {"object": "", "version": 1, "hash": ""}
 
 
 def _readFields(
@@ -485,19 +490,20 @@ def _readVersionableGroup(
 
     If *declaredType* is a Versionable subclass (e.g., from the parent's field
     annotation), use it directly to resolve field types. Otherwise fall back to
-    looking up the class by the ``__OBJECT__`` name from file metadata.
+    looking up the class by the ``object`` name from file metadata. Falls
+    back to the legacy ``__OBJECT__`` attribute for 0.1.x files.
 
     When *ctx* is provided, array fields inside the nested object get lazy
-    sentinels. The set of lazy field names is stored under ``__lazy__`` so
-    ``_deserializeVersionable`` can apply ``makeLazyInstance``.
+    sentinels. The set of lazy field names is stored under ``__ver_lazy__``
+    so ``_deserializeVersionable`` can apply ``makeLazyInstance``.
     """
     metaGroup = group[_VERSIONABLE_GROUP]
-    objectName = str(metaGroup.attrs.get("__OBJECT__", ""))
+    objectName = str(metaGroup.attrs.get("object", metaGroup.attrs.get("__OBJECT__", "")))
 
     result: dict[str, Any] = {
-        "__OBJECT__": objectName,
-        "__VERSION__": int(metaGroup.attrs.get("__VERSION__", 1)),
-        "__HASH__": str(metaGroup.attrs.get("__HASH__", "")),
+        "object": objectName,
+        "version": int(metaGroup.attrs.get("version", metaGroup.attrs.get("__VERSION__", 1))),
+        "hash": str(metaGroup.attrs.get("hash", metaGroup.attrs.get("__HASH__", ""))),
     }
 
     # Use declared type if available, otherwise resolve by name
@@ -510,7 +516,7 @@ def _readVersionableGroup(
     nestedFields, lazyFields = _readFields(group, nestedFieldTypes, ctx)
     result.update(nestedFields)
     if lazyFields:
-        result["__lazy__"] = lazyFields
+        result["__ver_lazy__"] = lazyFields
     return result
 
 

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -498,6 +498,12 @@ def _readVersionableGroup(
     so ``_deserializeVersionable`` can apply ``makeLazyInstance``.
     """
     metaGroup = group[_VERSIONABLE_GROUP]
+    fileFormat = metaGroup.attrs.get("format", metaGroup.attrs.get("__FORMAT__"))
+    if fileFormat is not None:
+        raise BackendError(
+            f"File uses versionable format {fileFormat!r}, but this version only supports "
+            f"format-less files. Upgrade versionable to read this file."
+        )
     objectName = str(metaGroup.attrs.get("object", metaGroup.attrs.get("__OBJECT__", "")))
 
     # Use declared type if available, otherwise resolve by name

--- a/src/versionable/_hdf5_backend.py
+++ b/src/versionable/_hdf5_backend.py
@@ -500,12 +500,6 @@ def _readVersionableGroup(
     metaGroup = group[_VERSIONABLE_GROUP]
     objectName = str(metaGroup.attrs.get("object", metaGroup.attrs.get("__OBJECT__", "")))
 
-    result: dict[str, Any] = {
-        "object": objectName,
-        "version": int(metaGroup.attrs.get("version", metaGroup.attrs.get("__VERSION__", 1))),
-        "hash": str(metaGroup.attrs.get("hash", metaGroup.attrs.get("__HASH__", ""))),
-    }
-
     # Use declared type if available, otherwise resolve by name
     cls: type | None = None
     if isinstance(declaredType, type) and issubclass(declaredType, Versionable):
@@ -514,7 +508,15 @@ def _readVersionableGroup(
         cls = _resolveClass(objectName)
     nestedFieldTypes = _resolveFields(cls) if cls is not None else {}
     nestedFields, lazyFields = _readFields(group, nestedFieldTypes, ctx)
-    result.update(nestedFields)
+
+    # Envelope is namespaced under ``__versionable__`` so it can't collide
+    # with user-declared field names like ``object``/``version``/``hash``.
+    result: dict[str, Any] = dict(nestedFields)
+    result["__versionable__"] = {
+        "object": objectName,
+        "version": int(metaGroup.attrs.get("version", metaGroup.attrs.get("__VERSION__", 1))),
+        "hash": str(metaGroup.attrs.get("hash", metaGroup.attrs.get("__HASH__", ""))),
+    }
     if lazyFields:
         result["__ver_lazy__"] = lazyFields
     return result

--- a/src/versionable/_hdf5_session.py
+++ b/src/versionable/_hdf5_session.py
@@ -145,9 +145,9 @@ class Hdf5Session[T: Versionable]:
                 # Write __versionable__ metadata for new files
                 meta = metadata(self._cls)
                 metaGroup = self._root.create_group(_VERSIONABLE_GROUP)
-                metaGroup.attrs["__OBJECT__"] = meta.name
-                metaGroup.attrs["__VERSION__"] = meta.version
-                metaGroup.attrs["__HASH__"] = meta.hash
+                metaGroup.attrs["object"] = meta.name
+                metaGroup.attrs["version"] = meta.version
+                metaGroup.attrs["hash"] = meta.hash
 
                 # If an instance was provided, persist all its fields
                 if self._instance is not None:
@@ -176,19 +176,16 @@ class Hdf5Session[T: Versionable]:
         # Validate metadata — no migration support
         fileMeta = _readMeta(self._root)
         meta = metadata(self._cls)
-        if fileMeta["__OBJECT__"] != meta.name:
+        if fileMeta["object"] != meta.name:
             raise BackendError(
-                f"Cannot resume: file contains type {fileMeta['__OBJECT__']!r}, "
-                f"but session was opened with {meta.name!r}."
+                f"Cannot resume: file contains type {fileMeta['object']!r}, but session was opened with {meta.name!r}."
             )
-        if fileMeta["__VERSION__"] != meta.version:
+        if fileMeta["version"] != meta.version:
             raise BackendError(
-                f"Cannot resume: file has version {fileMeta['__VERSION__']}, but class has version {meta.version}."
+                f"Cannot resume: file has version {fileMeta['version']}, but class has version {meta.version}."
             )
-        if fileMeta["__HASH__"] != meta.hash:
-            raise BackendError(
-                f"Cannot resume: file has hash {fileMeta['__HASH__']!r}, but class has hash {meta.hash!r}."
-            )
+        if fileMeta["hash"] != meta.hash:
+            raise BackendError(f"Cannot resume: file has hash {fileMeta['hash']!r}, but class has hash {meta.hash!r}.")
 
         # Load existing fields
         fields, _ = _readFields(self._root, self._fieldTypes)

--- a/src/versionable/_json_backend.py
+++ b/src/versionable/_json_backend.py
@@ -45,9 +45,9 @@ class JsonBackend(Backend):
 
         data = {
             "__versionable__": {
-                "__OBJECT__": meta["name"],
-                "__VERSION__": meta["version"],
-                "__HASH__": meta["hash"],
+                "object": meta["name"],
+                "version": meta["version"],
+                "hash": meta["hash"],
             },
             **fields,
         }
@@ -70,7 +70,7 @@ class JsonBackend(Backend):
         if not isinstance(metaTable, dict):
             raise BackendError(f"Missing or invalid __versionable__ metadata in {path}")
 
-        fileFormat = metaTable.get("__FORMAT__")
+        fileFormat = metaTable.get("format", metaTable.get("__FORMAT__"))
         if fileFormat is not None:
             raise BackendError(
                 f"File {path} uses versionable format {fileFormat!r}, but this version only supports "
@@ -78,9 +78,9 @@ class JsonBackend(Backend):
             )
 
         meta = {
-            "__OBJECT__": metaTable.get("__OBJECT__", ""),
-            "__VERSION__": metaTable.get("__VERSION__"),
-            "__HASH__": metaTable.get("__HASH__", ""),
+            "object": metaTable.get("object", metaTable.get("__OBJECT__", "")),
+            "version": metaTable.get("version", metaTable.get("__VERSION__")),
+            "hash": metaTable.get("hash", metaTable.get("__HASH__", "")),
         }
 
         return data, meta

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -6,14 +6,14 @@ Stores Versionable objects as TOML files.  Metadata is stored in a
 Nested Versionable objects use native TOML table syntax::
 
     [__versionable__]
-    __OBJECT__ = "Config"
-    __VERSION__ = 1
+    object = "Config"
+    version = 1
 
     name = "myapp"
 
     [point]
-    __OBJECT__ = "Point"
-    __VERSION__ = 1
+    object = "Point"
+    version = 1
     x = 1.0
     y = 2.0
 
@@ -43,6 +43,8 @@ from versionable._backend import Backend, registerBackend
 from versionable._base import _resolveFields
 from versionable._types import serialize
 from versionable.errors import BackendError
+
+_ENVELOPE_KEYS: frozenset[str] = frozenset({"object", "version", "hash"})
 
 
 class TomlBackend(Backend):
@@ -74,9 +76,9 @@ class TomlBackend(Backend):
 
         data: dict[str, Any] = {
             "__versionable__": {
-                "__OBJECT__": meta["name"],
-                "__VERSION__": meta["version"],
-                "__HASH__": meta["hash"],
+                "object": meta["name"],
+                "version": meta["version"],
+                "hash": meta["hash"],
             },
         }
         # TOML cannot represent None — omit those fields
@@ -106,7 +108,7 @@ class TomlBackend(Backend):
         metaTable = data.pop("__versionable__", {})
         if not isinstance(metaTable, dict):
             raise BackendError(f"Expected __versionable__ to be a table in {path}, got {type(metaTable).__name__}")
-        fileFormat = metaTable.get("__FORMAT__")
+        fileFormat = metaTable.get("format", metaTable.get("__FORMAT__"))
         if fileFormat is not None:
             raise BackendError(
                 f"File {path} uses versionable format {fileFormat!r}, but this version only supports "
@@ -114,12 +116,12 @@ class TomlBackend(Backend):
             )
 
         meta = {
-            "__OBJECT__": metaTable.get("__OBJECT__", ""),
-            "__VERSION__": metaTable.get("__VERSION__"),
-            "__HASH__": metaTable.get("__HASH__", ""),
+            "object": metaTable.get("object", metaTable.get("__OBJECT__", "")),
+            "version": metaTable.get("version", metaTable.get("__VERSION__")),
+            "hash": metaTable.get("hash", metaTable.get("__HASH__", "")),
         }
 
-        # Unwrap __json__ wrappers (ndarray blobs)
+        # Unwrap __ver_json__ wrappers (ndarray blobs)
         data = _fromTomlSafe(data)
 
         return data, meta
@@ -133,16 +135,16 @@ class TomlBackend(Backend):
 def _toTomlSafe(value: Any) -> Any:
     """Convert a value to a TOML-safe representation.
 
-    - Nested Versionable dicts (with ``__OBJECT__``) are kept as native
+    - Nested Versionable dicts (with ``object``) are kept as native
       TOML tables — they naturally become ``[field_name]`` sections.
-    - ndarray dicts (with ``__ndarray__``) are stored as JSON strings
+    - ndarray dicts (with ``__ver_ndarray__``) are stored as JSON strings
       since they have no natural TOML representation.
     - ``None`` values are stripped (TOML cannot represent them).
     """
     if isinstance(value, dict):
         # ndarray blob — must use JSON wrapper
-        if "__ndarray__" in value:
-            return {"__json__": json.dumps(value, default=str)}
+        if "__ver_ndarray__" in value:
+            return {"__ver_json__": json.dumps(value, default=str)}
         # Nested Versionable or plain dict — keep as TOML table
         return {k: _toTomlSafe(v) for k, v in value.items() if v is not None}
     if isinstance(value, (list, tuple)):
@@ -151,8 +153,13 @@ def _toTomlSafe(value: Any) -> Any:
 
 
 def _fromTomlSafe(value: Any) -> Any:
-    """Reverse of ``_toTomlSafe`` — unwrap ``__json__`` wrappers."""
+    """Reverse of ``_toTomlSafe`` — unwrap ``__ver_json__`` wrappers.
+
+    Also accepts the legacy ``__json__`` wrapper from 0.1.x files.
+    """
     if isinstance(value, dict):
+        if "__ver_json__" in value and len(value) == 1:
+            return json.loads(value["__ver_json__"])
         if "__json__" in value and len(value) == 1:
             return json.loads(value["__json__"])
         return {k: _fromTomlSafe(v) for k, v in value.items()}
@@ -240,7 +247,7 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
 
         # Metadata keys — always keep uncommented (even inside nested sections)
         key = stripped.split("=", 1)[0].strip()
-        if key.startswith("__") and key.endswith("__"):
+        if key in _ENVELOPE_KEYS:
             result.append(line)
             continue
 

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -44,8 +44,6 @@ from versionable._base import _resolveFields
 from versionable._types import serialize
 from versionable.errors import BackendError
 
-_ENVELOPE_KEYS: frozenset[str] = frozenset({"object", "version", "hash"})
-
 
 class TomlBackend(Backend):
     """TOML file backend for configuration data."""
@@ -242,12 +240,6 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
 
         # __versionable__ section — always keep uncommented
         if inMetaSection:
-            result.append(line)
-            continue
-
-        # Metadata keys — always keep uncommented (even inside nested sections)
-        key = stripped.split("=", 1)[0].strip()
-        if key in _ENVELOPE_KEYS:
             result.append(line)
             continue
 

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -3,7 +3,9 @@
 Stores Versionable objects as TOML files.  Metadata is stored in a
 ``[__versionable__]`` table to avoid conflicts with field names.
 
-Nested Versionable objects use native TOML table syntax::
+Nested Versionable objects use native TOML table syntax, with each
+nested object's metadata under its own ``[<field>.__versionable__]``
+sub-table::
 
     [__versionable__]
     object = "Config"
@@ -12,10 +14,12 @@ Nested Versionable objects use native TOML table syntax::
     name = "myapp"
 
     [point]
-    object = "Point"
-    version = 1
     x = 1.0
     y = 2.0
+
+    [point.__versionable__]
+    object = "Point"
+    version = 1
 
 Supports ``commentDefaults=True`` to comment out fields that are at
 their default value, producing human-friendly config files.

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -536,9 +536,11 @@ def _serializeVersionable(obj: Versionable, visited: set[int], path: str) -> dic
     meta = getMeta(type(obj))
     fields = _resolveFields(type(obj))
     result: dict[str, Any] = {
-        "object": meta.name,
-        "version": meta.version,
-        "hash": meta.hash,
+        "__versionable__": {
+            "object": meta.name,
+            "version": meta.version,
+            "hash": meta.hash,
+        },
     }
     visited.add(objId)
     try:

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -536,9 +536,9 @@ def _serializeVersionable(obj: Versionable, visited: set[int], path: str) -> dic
     meta = getMeta(type(obj))
     fields = _resolveFields(type(obj))
     result: dict[str, Any] = {
-        "__OBJECT__": meta.name,
-        "__VERSION__": meta.version,
-        "__HASH__": meta.hash,
+        "object": meta.name,
+        "version": meta.version,
+        "hash": meta.hash,
     }
     visited.add(objId)
     try:
@@ -558,13 +558,13 @@ def _serializeVersionable(obj: Versionable, visited: set[int], path: str) -> dic
 def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Versionable:
     """Deserialize a dict to a Versionable instance.
 
-    If the dict contains a ``__lazy__`` key (set by the HDF5 backend's
+    If the dict contains a ``__ver_lazy__`` key (set by the HDF5 backend's
     recursive lazy reader), lazy sentinels are passed through without
     deserialization and the instance is wrapped with ``makeLazyInstance``.
     """
     import dataclasses
 
-    lazyFields: set[str] = data.pop("__lazy__", set())
+    lazyFields: set[str] = data.pop("__ver_lazy__", set())
 
     meta = cls._serializer_meta_
     fields = _resolveFields(cls)
@@ -608,7 +608,7 @@ def _serializeNdarray(arr: Any) -> dict[str, Any]:
     buf = io.BytesIO()
     numpy.savez_compressed(buf, data=arr)
     encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-    return {"__ndarray__": True, "dtype": str(arr.dtype), "shape": list(arr.shape), "data": encoded}
+    return {"__ver_ndarray__": True, "dtype": str(arr.dtype), "shape": list(arr.shape), "data": encoded}
 
 
 def _deserializeNdarray(data: Any) -> Any:
@@ -616,7 +616,7 @@ def _deserializeNdarray(data: Any) -> Any:
     numpy = requireNumpy("ndarray deserialization")
     if isinstance(data, numpy.ndarray):
         return data
-    if isinstance(data, dict) and data.get("__ndarray__"):
+    if isinstance(data, dict) and (data.get("__ver_ndarray__") or data.get("__ndarray__")):
         raw = base64.b64decode(data["data"])
         buf = io.BytesIO(raw)
         return numpy.load(buf)["data"]

--- a/src/versionable/_yaml_backend.py
+++ b/src/versionable/_yaml_backend.py
@@ -11,9 +11,9 @@ TOML backend convention::
     - 1
     - 2
     __versionable__:
-      __OBJECT__: SensorConfig
-      __VERSION__: 1
-      __HASH__: 9d6951
+      object: SensorConfig
+      version: 1
+      hash: 9d6951
 
 YAML handles ``None`` natively (as ``null``), so unlike TOML no fields
 are lost on round-trip.
@@ -34,6 +34,8 @@ from versionable._backend import Backend, registerBackend
 from versionable._base import _resolveFields
 from versionable._types import serialize
 from versionable.errors import BackendError
+
+_ENVELOPE_KEYS: frozenset[str] = frozenset({"object", "version", "hash"})
 
 
 class YamlBackend(Backend):
@@ -66,9 +68,9 @@ class YamlBackend(Backend):
             data[key] = _toYamlSafe(value)
 
         data["__versionable__"] = {
-            "__OBJECT__": meta["name"],
-            "__VERSION__": meta["version"],
-            "__HASH__": meta["hash"],
+            "object": meta["name"],
+            "version": meta["version"],
+            "hash": meta["hash"],
         }
 
         commentDefaults: bool = kwargs.get("commentDefaults", False)
@@ -94,7 +96,7 @@ class YamlBackend(Backend):
         metaTable = data.pop("__versionable__", {})
         if not isinstance(metaTable, dict):
             raise BackendError(f"Expected __versionable__ to be a mapping in {path}, got {type(metaTable).__name__}")
-        fileFormat = metaTable.get("__FORMAT__")
+        fileFormat = metaTable.get("format", metaTable.get("__FORMAT__"))
         if fileFormat is not None:
             raise BackendError(
                 f"File {path} uses versionable format {fileFormat!r}, but this version only supports "
@@ -102,9 +104,9 @@ class YamlBackend(Backend):
             )
 
         meta = {
-            "__OBJECT__": metaTable.get("__OBJECT__", ""),
-            "__VERSION__": metaTable.get("__VERSION__"),
-            "__HASH__": metaTable.get("__HASH__", ""),
+            "object": metaTable.get("object", metaTable.get("__OBJECT__", "")),
+            "version": metaTable.get("version", metaTable.get("__VERSION__")),
+            "hash": metaTable.get("hash", metaTable.get("__HASH__", "")),
         }
 
         try:
@@ -123,12 +125,12 @@ class YamlBackend(Backend):
 def _toYamlSafe(value: Any) -> Any:
     """Convert a value to a YAML-safe representation.
 
-    ndarray dicts (with ``__ndarray__``) are stored as JSON strings
+    ndarray dicts (with ``__ver_ndarray__``) are stored as JSON strings
     since they have no natural YAML representation.
     """
     if isinstance(value, dict):
-        if "__ndarray__" in value:
-            return {"__json__": json.dumps(value, default=str)}
+        if "__ver_ndarray__" in value:
+            return {"__ver_json__": json.dumps(value, default=str)}
         return {k: _toYamlSafe(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_toYamlSafe(v) for v in value]
@@ -136,8 +138,13 @@ def _toYamlSafe(value: Any) -> Any:
 
 
 def _fromYamlSafe(value: Any) -> Any:
-    """Reverse of ``_toYamlSafe`` — unwrap ``__json__`` wrappers."""
+    """Reverse of ``_toYamlSafe`` — unwrap ``__ver_json__`` wrappers.
+
+    Also accepts the legacy ``__json__`` wrapper from 0.1.x files.
+    """
     if isinstance(value, dict):
+        if "__ver_json__" in value and len(value) == 1:
+            return json.loads(value["__ver_json__"])
         if "__json__" in value and len(value) == 1:
             return json.loads(value["__json__"])
         return {k: _fromYamlSafe(v) for k, v in value.items()}
@@ -237,9 +244,9 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
 
             # Check if this block matches the default
             if key in defaultBlocks and key in originalBlocks and defaultBlocks[key] == originalBlocks[key]:
-                # Peek ahead: if the block contains __OBJECT__, it's a nested
-                # Versionable — keep the key line and metadata uncommented,
-                # only comment field value lines.
+                # Peek ahead: if the block contains an ``object:`` line, it's
+                # a nested Versionable — keep the key line and metadata
+                # uncommented, only comment field value lines.
                 blockLines: list[str] = []
                 j = i + 1
                 while j < len(lines):
@@ -251,14 +258,14 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
                     else:
                         break
 
-                hasNestedMeta = any("__OBJECT__" in bl for bl in blockLines)
+                hasNestedMeta = any("object:" in bl for bl in blockLines)
                 if hasNestedMeta:
                     # Keep key line uncommented
                     result.append(lines[i])
                     for bl in blockLines:
                         blStripped = bl.strip()
                         metaKey = blStripped.split(":")[0] if ":" in blStripped else ""
-                        if metaKey.startswith("__") and metaKey.endswith("__"):
+                        if metaKey in _ENVELOPE_KEYS:
                             result.append(bl)
                         else:
                             result.append("# " + bl)

--- a/src/versionable/_yaml_backend.py
+++ b/src/versionable/_yaml_backend.py
@@ -35,8 +35,6 @@ from versionable._base import _resolveFields
 from versionable._types import serialize
 from versionable.errors import BackendError
 
-_ENVELOPE_KEYS: frozenset[str] = frozenset({"object", "version", "hash"})
-
 
 class YamlBackend(Backend):
     """YAML file backend for human-readable config and data files."""
@@ -244,9 +242,10 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
 
             # Check if this block matches the default
             if key in defaultBlocks and key in originalBlocks and defaultBlocks[key] == originalBlocks[key]:
-                # Peek ahead: if the block contains an ``object:`` line, it's
-                # a nested Versionable — keep the key line and metadata
-                # uncommented, only comment field value lines.
+                # Peek ahead: if the block contains a ``__versionable__:``
+                # line, it's a nested Versionable — keep the key line and
+                # the ``__versionable__:`` sub-block uncommented, only
+                # comment data-field value lines (siblings of the wrapper).
                 blockLines: list[str] = []
                 j = i + 1
                 while j < len(lines):
@@ -258,16 +257,25 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
                     else:
                         break
 
-                hasNestedMeta = any("object:" in bl for bl in blockLines)
+                hasNestedMeta = any(bl.lstrip(" ").startswith("__versionable__:") for bl in blockLines)
                 if hasNestedMeta:
-                    # Keep key line uncommented
+                    # Keep key line uncommented; keep the ``__versionable__:``
+                    # sub-block uncommented; comment data fields at the
+                    # nested level (i.e. siblings of ``__versionable__:``).
                     result.append(lines[i])
+                    metaIndent: int | None = None
                     for bl in blockLines:
-                        blStripped = bl.strip()
-                        metaKey = blStripped.split(":")[0] if ":" in blStripped else ""
-                        if metaKey in _ENVELOPE_KEYS:
+                        blLstrip = bl.lstrip(" ")
+                        blIndent = len(bl) - len(blLstrip)
+                        if blLstrip.startswith("__versionable__:"):
+                            metaIndent = blIndent
+                            result.append(bl)
+                        elif metaIndent is not None and blIndent > metaIndent:
+                            # Inside the envelope sub-block
                             result.append(bl)
                         else:
+                            # Sibling of __versionable__ (a data field)
+                            metaIndent = None
                             result.append("# " + bl)
                 else:
                     # Simple field — comment the whole block

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -967,6 +967,53 @@ class TestHdf5BackCompat:
         assert loaded.point.x == 1.5
         assert loaded.point.y == 2.5
 
+    def test_nestedFutureFormatRaises(self, tmp_path: Path) -> None:
+        """A nested ``__versionable__`` group with a future ``format`` attr also raises."""
+        from .conftest import WithNested
+
+        p = tmp_path / "nested_future.h5"
+        with h5py.File(p, "w") as f:
+            outer = f.create_group("__versionable__")
+            outer.attrs["object"] = "WithNested"
+            outer.attrs["version"] = 1
+            outer.attrs["hash"] = "db925f"
+            f.attrs["name"] = "origin"
+            # Nested ``point`` group with a future-format marker
+            point = f.create_group("point")
+            inner = point.create_group("__versionable__")
+            inner.attrs["object"] = "Inner"
+            inner.attrs["version"] = 1
+            inner.attrs["hash"] = "e37514"
+            inner.attrs["format"] = 2
+            point.attrs["x"] = 1.5
+            point.attrs["y"] = 2.5
+
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(WithNested, p)
+
+    def test_nestedLegacyFutureFormatRaises(self, tmp_path: Path) -> None:
+        """The legacy ``__FORMAT__`` attr on a nested envelope also raises."""
+        from .conftest import WithNested
+
+        p = tmp_path / "nested_legacy_future.h5"
+        with h5py.File(p, "w") as f:
+            outer = f.create_group("__versionable__")
+            outer.attrs["__OBJECT__"] = "WithNested"
+            outer.attrs["__VERSION__"] = 1
+            outer.attrs["__HASH__"] = "db925f"
+            f.attrs["name"] = "origin"
+            point = f.create_group("point")
+            inner = point.create_group("__versionable__")
+            inner.attrs["__OBJECT__"] = "Inner"
+            inner.attrs["__VERSION__"] = 1
+            inner.attrs["__HASH__"] = "e37514"
+            inner.attrs["__FORMAT__"] = 2
+            point.attrs["x"] = 1.5
+            point.attrs["y"] = 2.5
+
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(WithNested, p)
+
 
 def _assertNoJsonAttrs(group: h5py.Group) -> None:
     """Recursively verify no attributes contain JSON strings."""

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -110,8 +110,8 @@ class TestHdf5Metadata:
 
         with h5py.File(p, "r") as f:
             meta = f["__versionable__"]
-            assert meta.attrs["__OBJECT__"] == "SimpleConfig"
-            assert meta.attrs["__VERSION__"] == 1
+            assert meta.attrs["object"] == "SimpleConfig"
+            assert meta.attrs["version"] == 1
 
 
 class TestHdf5Compression:
@@ -233,40 +233,40 @@ class TestHdf5Errors:
         p = tmp_path / "future.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "SimpleConfig"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = ""
-            meta.attrs["__FORMAT__"] = 2
+            meta.attrs["object"] = "SimpleConfig"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = ""
+            meta.attrs["format"] = 2
 
         with pytest.raises(BackendError, match="Upgrade versionable"):
             versionable.load(SimpleConfig, p)
 
     def test_unregisteredClassInLoad(self, tmp_path: Path) -> None:
-        """load() raises when the file's __OBJECT__ isn't in the registry."""
+        """load() raises when the file's ``object`` isn't in the registry."""
         from versionable._hdf5_backend import Hdf5Backend
 
         # Write a file with a class name that won't be in the registry
         p = tmp_path / "unknown.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "NonexistentClass"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = "abc123"
+            meta.attrs["object"] = "NonexistentClass"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = "abc123"
 
         be = Hdf5Backend()
         with pytest.raises(BackendError, match="Unknown Versionable type"):
             be.load(p)
 
     def test_unregisteredClassInLoadLazy(self, tmp_path: Path) -> None:
-        """loadLazy() raises when cls is None and __OBJECT__ isn't registered."""
+        """loadLazy() raises when cls is None and ``object`` isn't registered."""
         from versionable._hdf5_backend import Hdf5Backend
 
         p = tmp_path / "unknown_lazy.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "NonexistentClass"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = "abc123"
+            meta.attrs["object"] = "NonexistentClass"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = "abc123"
 
         be = Hdf5Backend()
         with pytest.raises(BackendError, match="Unknown Versionable type"):
@@ -497,7 +497,7 @@ class TestNativeNestedVersionable:
             point = f["point"]
             assert isinstance(point, h5py.Group)
             assert "__versionable__" in point
-            assert point["__versionable__"].attrs["__OBJECT__"] == "Inner"
+            assert point["__versionable__"].attrs["object"] == "Inner"
 
     def test_listVersionable(self, tmp_path: Path) -> None:
         @dataclass
@@ -849,9 +849,9 @@ class TestUnknownFieldHandling:
         p = tmp_path / "extra.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "UnkIgnore"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = ""
+            meta.attrs["object"] = "UnkIgnore"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = ""
             f.attrs["name"] = "test"
             f.attrs["obsolete"] = 42
 
@@ -869,9 +869,9 @@ class TestUnknownFieldHandling:
         p = tmp_path / "extra.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "UnkError"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = ""
+            meta.attrs["object"] = "UnkError"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = ""
             f.attrs["name"] = "test"
             f.attrs["obsolete"] = 42
 
@@ -897,9 +897,9 @@ class TestHdf5Migration:
         p = tmp_path / "v1_sensor.h5"
         with h5py.File(p, "w") as f:
             meta = f.create_group("__versionable__")
-            meta.attrs["__OBJECT__"] = "MigSensor"
-            meta.attrs["__VERSION__"] = 1
-            meta.attrs["__HASH__"] = ""
+            meta.attrs["object"] = "MigSensor"
+            meta.attrs["version"] = 1
+            meta.attrs["hash"] = ""
             f.attrs["name"] = "accelerometer"
 
         loaded = versionable.load(SensorV2, p)

--- a/tests/test_hdf5_backend.py
+++ b/tests/test_hdf5_backend.py
@@ -907,6 +907,67 @@ class TestHdf5Migration:
         assert loaded.rate_Hz == 1000.0
 
 
+class TestHdf5BackCompat:
+    """Read-side compatibility for files written by versionable 0.1.x."""
+
+    def test_loadOldFormatEnvelope(self, tmp_path: Path) -> None:
+        """A file with legacy __OBJECT__/__VERSION__/__HASH__ attrs still loads."""
+        p = tmp_path / "old.h5"
+        with h5py.File(p, "w") as f:
+            meta = f.create_group("__versionable__")
+            meta.attrs["__OBJECT__"] = "SimpleConfig"
+            meta.attrs["__VERSION__"] = 1
+            meta.attrs["__HASH__"] = "ed3a90"
+            f.attrs["name"] = "legacy"
+            f.attrs["debug"] = True
+            f.attrs["retries"] = 7
+
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.name == "legacy"
+        assert loaded.debug is True
+        assert loaded.retries == 7
+
+    def test_oldFormatFutureFormatRaises(self, tmp_path: Path) -> None:
+        """The legacy __FORMAT__ attr still triggers the upgrade-required error."""
+        p = tmp_path / "old_future.h5"
+        with h5py.File(p, "w") as f:
+            meta = f.create_group("__versionable__")
+            meta.attrs["__OBJECT__"] = "SimpleConfig"
+            meta.attrs["__VERSION__"] = 1
+            meta.attrs["__HASH__"] = ""
+            meta.attrs["__FORMAT__"] = 2
+
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(SimpleConfig, p)
+
+    def test_loadOldFormatNestedVersionable(self, tmp_path: Path) -> None:
+        """A nested Versionable subgroup with legacy attrs loads correctly."""
+        from .conftest import Inner, WithNested
+
+        p = tmp_path / "old_nested.h5"
+        with h5py.File(p, "w") as f:
+            # Outer envelope (legacy attrs)
+            outer = f.create_group("__versionable__")
+            outer.attrs["__OBJECT__"] = "WithNested"
+            outer.attrs["__VERSION__"] = 1
+            outer.attrs["__HASH__"] = "db925f"
+            f.attrs["name"] = "origin"
+            # Nested point with legacy envelope
+            point = f.create_group("point")
+            inner = point.create_group("__versionable__")
+            inner.attrs["__OBJECT__"] = "Inner"
+            inner.attrs["__VERSION__"] = 1
+            inner.attrs["__HASH__"] = "e37514"
+            point.attrs["x"] = 1.5
+            point.attrs["y"] = 2.5
+
+        loaded = versionable.load(WithNested, p)
+        assert loaded.name == "origin"
+        assert isinstance(loaded.point, Inner)
+        assert loaded.point.x == 1.5
+        assert loaded.point.y == 2.5
+
+
 def _assertNoJsonAttrs(group: h5py.Group) -> None:
     """Recursively verify no attributes contain JSON strings."""
     for attrName in group.attrs:

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
+try:
+    import numpy as np
+    import numpy.typing as npt
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
 import versionable
+from versionable._base import Versionable
 from versionable.errors import BackendError, ConverterError, VersionError
 
 from .conftest import (
@@ -15,6 +25,15 @@ from .conftest import (
     WithLiteral,
     WithSkipDefaults,
 )
+
+if _HAS_NUMPY:
+
+    @dataclass
+    class _JsonArrLegacy(Versionable, version=1, name="JsonArrLegacy", register=True):
+        """Test class for back-compat ndarray reads in JSON files."""
+
+        label: str
+        data: npt.NDArray[np.float64]
 
 
 class TestJsonMetadata:
@@ -210,3 +229,91 @@ class TestErrors:
         )
         with pytest.raises(BackendError, match="Upgrade versionable"):
             versionable.load(SimpleConfig, p)
+
+
+class TestJsonBackCompat:
+    """Read-side compatibility for files written by versionable 0.1.x."""
+
+    def test_loadOldFormatEnvelope(self, tmp_path: Path) -> None:
+        """A file with the legacy __OBJECT__/__VERSION__/__HASH__ keys still loads."""
+        p = tmp_path / "old.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "ed3a90",
+                    },
+                    "name": "legacy",
+                    "debug": True,
+                    "retries": 7,
+                }
+            )
+        )
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.name == "legacy"
+        assert loaded.debug is True
+        assert loaded.retries == 7
+
+    def test_oldFormatFutureFormatRaises(self, tmp_path: Path) -> None:
+        """The legacy __FORMAT__ key still triggers the upgrade-required error."""
+        p = tmp_path / "old_future.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                        "__FORMAT__": 2,
+                    },
+                    "name": "test",
+                }
+            )
+        )
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(SimpleConfig, p)
+
+    @pytest.mark.skipif(not _HAS_NUMPY, reason="numpy not installed")
+    def test_loadOldFormatNdarray(self, tmp_path: Path) -> None:
+        """A file with the legacy __ndarray__ sentinel still loads as a numpy array."""
+        # Save a fresh file then rewrite the envelope + sentinel keys to legacy form.
+        obj = _JsonArrLegacy(label="legacy-array", data=np.array([1.5, 2.5, 3.5], dtype=np.float64))
+        p = tmp_path / "old_arr.json"
+        versionable.save(obj, p)
+        text = p.read_text()
+        legacy = (
+            text.replace('"object":', '"__OBJECT__":')
+            .replace('"version":', '"__VERSION__":')
+            .replace('"hash":', '"__HASH__":')
+            .replace('"__ver_ndarray__":', '"__ndarray__":')
+        )
+        p.write_text(legacy)
+
+        loaded = versionable.load(_JsonArrLegacy, p)
+        assert loaded.label == "legacy-array"
+        np.testing.assert_array_equal(loaded.data, np.array([1.5, 2.5, 3.5]))
+
+    def test_newKeysPreferredWhenBothPresent(self, tmp_path: Path) -> None:
+        """Mixed old + new envelope keys: new wins, no errors."""
+        p = tmp_path / "mixed.json"
+        p.write_text(
+            json.dumps(
+                {
+                    "__versionable__": {
+                        # Old keys point at a different class — must be ignored
+                        "__OBJECT__": "WrongClass",
+                        "__VERSION__": 99,
+                        "__HASH__": "deadbe",
+                        # New keys are correct — must win
+                        "object": "SimpleConfig",
+                        "version": 1,
+                        "hash": "ed3a90",
+                    },
+                    "name": "winner",
+                }
+            )
+        )
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.name == "winner"

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -50,6 +50,26 @@ class TestJsonMetadata:
         assert "hash" in meta
         assert meta["version"] == 1
 
+    def test_nestedHasWrappedEnvelope(self, tmp_path: Path) -> None:
+        """Nested Versionable values get their own ``__versionable__`` envelope."""
+        from .conftest import Inner, WithNested
+
+        obj = WithNested(name="origin", point=Inner(x=1.0, y=2.0))
+        p = tmp_path / "out.json"
+        versionable.save(obj, p)
+
+        data = json.loads(p.read_text())
+        # Root envelope
+        assert data["__versionable__"]["object"] == "WithNested"
+        # Nested envelope is wrapped under __versionable__, never flat
+        assert "__versionable__" in data["point"]
+        assert data["point"]["__versionable__"]["object"] == "Inner"
+        assert "object" not in data["point"]
+        # Round-trips correctly
+        loaded = versionable.load(WithNested, p)
+        assert loaded.point.x == 1.0
+        assert loaded.point.y == 2.0
+
     def test_prettyPrinted(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test")
         p = tmp_path / "out.json"

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -26,10 +26,10 @@ class TestJsonMetadata:
         data = json.loads(p.read_text())
         assert "__versionable__" in data
         meta = data["__versionable__"]
-        assert "__OBJECT__" in meta
-        assert "__VERSION__" in meta
-        assert "__HASH__" in meta
-        assert meta["__VERSION__"] == 1
+        assert "object" in meta
+        assert "version" in meta
+        assert "hash" in meta
+        assert meta["version"] == 1
 
     def test_prettyPrinted(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test")
@@ -78,9 +78,9 @@ class TestUnknownFields:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "SimpleConfig",
+                        "version": 1,
+                        "hash": "",
                     },
                     "name": "test",
                     "debug": False,
@@ -107,9 +107,9 @@ class TestJsonLiteral:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "WithLiteral",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "WithLiteral",
+                        "version": 1,
+                        "hash": "",
                     },
                     "name": "test",
                     "mode": "banana",
@@ -125,9 +125,9 @@ class TestJsonLiteral:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "WithLiteral",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "WithLiteral",
+                        "version": 1,
+                        "hash": "",
                     },
                     "name": "test",
                     "mode": "banana",
@@ -154,7 +154,7 @@ class TestJsonMissingVersion:
         p.write_text(json.dumps({"name": "test", "debug": False, "retries": 3}))
         with caplog.at_level("WARNING"):
             versionable.load(SimpleConfig, p)
-        assert "No __VERSION__" in caplog.text
+        assert "No version" in caplog.text
         assert "SimpleConfig" in caplog.text
 
     def test_assumeVersionOverride(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -164,7 +164,7 @@ class TestJsonMissingVersion:
         with caplog.at_level("WARNING"):
             loaded = versionable.load(SimpleConfig, p, assumeVersion=1)
         assert loaded.name == "test"
-        assert "No __VERSION__" not in caplog.text
+        assert "No version" not in caplog.text
 
 
 class TestErrors:
@@ -182,9 +182,9 @@ class TestErrors:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 999,
-                        "__HASH__": "",
+                        "object": "SimpleConfig",
+                        "version": 999,
+                        "hash": "",
                     },
                     "name": "test",
                 }
@@ -199,10 +199,10 @@ class TestErrors:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
-                        "__FORMAT__": 2,
+                        "object": "SimpleConfig",
+                        "version": 1,
+                        "hash": "",
+                        "format": 2,
                     },
                     "name": "test",
                 }

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -193,9 +193,9 @@ class TestEndToEndMigration:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "MigConfig",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "MigConfig",
+                        "version": 1,
+                        "hash": "",
                     },
                     "name": "old-config",
                 }
@@ -219,9 +219,9 @@ class TestEndToEndMigration:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "MigDoc",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "MigDoc",
+                        "version": 1,
+                        "hash": "",
                     },
                     "title": "My Document",
                 }
@@ -246,9 +246,9 @@ class TestEndToEndMigration:
             json.dumps(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "MigApp",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "MigApp",
+                        "version": 1,
+                        "hash": "",
                     },
                     "title": "Old App",
                 }
@@ -300,7 +300,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'title = "batch-processor"\ndebug = false\nretries = 5\n\n'
-            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 1\n__HASH__ = "5556c8"\n',
+            '[__versionable__]\nobject = "WCAddDefault"\nversion = 1\nhash = "5556c8"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 0.0
@@ -311,7 +311,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'name = "batch-processor"\ndebug = false\nretries = 5\n\n'
-            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 2\n__HASH__ = "ed3a90"\n',
+            '[__versionable__]\nobject = "WCAddDefault"\nversion = 2\nhash = "ed3a90"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 0.0
@@ -322,7 +322,7 @@ class TestAddDefaultBehavior:
         self._write_toml(
             p,
             'name = "batch-processor"\nretries = 5\ntimeout_s = 7.5\n\n'
-            '[__versionable__]\n__OBJECT__ = "WCAddDefault"\n__VERSION__ = 3\n__HASH__ = "ea7fc2"\n',
+            '[__versionable__]\nobject = "WCAddDefault"\nversion = 3\nhash = "ea7fc2"\n',
         )
         result = versionable.load(worker_config_v4, p)
         assert result.timeout_s == 7.5

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -30,8 +30,8 @@ class TestTomlMetadata:
 
         data = toml.loads(p.read_text())
         assert "__versionable__" in data
-        assert data["__versionable__"]["__OBJECT__"] == "SimpleConfig"
-        assert data["__versionable__"]["__VERSION__"] == 1
+        assert data["__versionable__"]["object"] == "SimpleConfig"
+        assert data["__versionable__"]["version"] == 1
 
     def test_nestedUsesNativeTable(self, tmp_path: Path) -> None:
         """Nested Versionable should use TOML table syntax, not JSON wrapper."""
@@ -42,10 +42,10 @@ class TestTomlMetadata:
         versionable.save(obj, p)
 
         data = toml.loads(p.read_text())
-        # point should be a native TOML table, not a __json__ wrapper
+        # point should be a native TOML table, not a __ver_json__ wrapper
         assert isinstance(data["point"], dict)
-        assert "__json__" not in data["point"]
-        assert data["point"]["__OBJECT__"] == "Inner"
+        assert "__ver_json__" not in data["point"]
+        assert data["point"]["object"] == "Inner"
         assert data["point"]["x"] == 1.0
 
         # Verify [point] section appears in the raw text
@@ -113,8 +113,8 @@ class TestTomlCommentDefaults:
         assert "[point]" in text
         assert "# [point]" not in text
         # __meta__ values within nested sections must never be commented
-        assert '__OBJECT__ = "Inner"' in text
-        assert "# __OBJECT__" not in text
+        assert 'object = "Inner"' in text
+        assert "# object" not in text
 
 
 class TestTomlLiteral:
@@ -132,7 +132,7 @@ class TestTomlLiteral:
         p.write_text(
             toml.dumps(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -148,7 +148,7 @@ class TestTomlLiteral:
         p.write_text(
             toml.dumps(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -174,7 +174,7 @@ class TestTomlMissingVersion:
         p.write_text('name = "test"\ndebug = false\nretries = 3\n')
         with caplog.at_level("WARNING"):
             versionable.load(SimpleConfig, p)
-        assert "No __VERSION__" in caplog.text
+        assert "No version" in caplog.text
         assert "SimpleConfig" in caplog.text
 
     def test_assumeVersionOverride(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -184,7 +184,7 @@ class TestTomlMissingVersion:
         with caplog.at_level("WARNING"):
             loaded = versionable.load(SimpleConfig, p, assumeVersion=1)
         assert loaded.name == "test"
-        assert "No __VERSION__" not in caplog.text
+        assert "No version" not in caplog.text
 
 
 class TestTomlErrors:
@@ -195,9 +195,7 @@ class TestTomlErrors:
     def test_futureFormatRaises(self, tmp_path: Path) -> None:
         p = tmp_path / "out.toml"
         p.write_text(
-            '[__versionable__]\n__OBJECT__ = "SimpleConfig"\n'
-            '__VERSION__ = 1\n__HASH__ = ""\n__FORMAT__ = 2\n\n'
-            'name = "test"\n'
+            '[__versionable__]\nobject = "SimpleConfig"\nversion = 1\nhash = ""\nformat = 2\n\nname = "test"\n'
         )
         with pytest.raises(BackendError, match="Upgrade versionable"):
             versionable.load(SimpleConfig, p)

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -7,9 +7,19 @@ import pytest
 
 pytest.importorskip("toml")
 
+from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    import numpy as np
+    import numpy.typing as npt
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
 import versionable
+from versionable._base import Versionable
 from versionable.errors import BackendError, ConverterError
 
 from .conftest import (
@@ -18,6 +28,15 @@ from .conftest import (
     WithLiteral,
     WithNested,
 )
+
+if _HAS_NUMPY:
+
+    @dataclass
+    class _TomlArrLegacy(Versionable, version=1, name="TomlArrLegacy", register=True):
+        """Test class for back-compat ndarray reads in TOML files."""
+
+        label: str
+        data: npt.NDArray[np.float64]
 
 
 class TestTomlMetadata:
@@ -199,3 +218,50 @@ class TestTomlErrors:
         )
         with pytest.raises(BackendError, match="Upgrade versionable"):
             versionable.load(SimpleConfig, p)
+
+
+class TestTomlBackCompat:
+    """Read-side compatibility for files written by versionable 0.1.x."""
+
+    def test_loadOldFormatEnvelope(self, tmp_path: Path) -> None:
+        """A file with the legacy __OBJECT__/__VERSION__/__HASH__ keys still loads."""
+        p = tmp_path / "old.toml"
+        p.write_text(
+            'name = "legacy"\ndebug = true\nretries = 7\n\n'
+            '[__versionable__]\n__OBJECT__ = "SimpleConfig"\n__VERSION__ = 1\n__HASH__ = "ed3a90"\n'
+        )
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.name == "legacy"
+        assert loaded.debug is True
+        assert loaded.retries == 7
+
+    def test_oldFormatFutureFormatRaises(self, tmp_path: Path) -> None:
+        """The legacy __FORMAT__ key still triggers the upgrade-required error."""
+        p = tmp_path / "old_future.toml"
+        p.write_text(
+            '[__versionable__]\n__OBJECT__ = "SimpleConfig"\n'
+            '__VERSION__ = 1\n__HASH__ = ""\n__FORMAT__ = 2\n\n'
+            'name = "test"\n'
+        )
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(SimpleConfig, p)
+
+    @pytest.mark.skipif(not _HAS_NUMPY, reason="numpy not installed")
+    def test_loadOldFormatNdarray(self, tmp_path: Path) -> None:
+        """A file with the legacy __json__ wrapper and __ndarray__ sentinel loads."""
+        obj = _TomlArrLegacy(label="legacy-array", data=np.array([7.0, 8.0, 9.0], dtype=np.float64))
+        p = tmp_path / "old_arr.toml"
+        versionable.save(obj, p)
+        text = p.read_text()
+        legacy = (
+            text.replace("object =", "__OBJECT__ =")
+            .replace("version =", "__VERSION__ =")
+            .replace("hash =", "__HASH__ =")
+            .replace("__ver_json__ =", "__json__ =")
+            .replace("__ver_ndarray__", "__ndarray__")
+        )
+        p.write_text(legacy)
+
+        loaded = versionable.load(_TomlArrLegacy, p)
+        assert loaded.label == "legacy-array"
+        np.testing.assert_array_equal(loaded.data, np.array([7.0, 8.0, 9.0]))

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -64,12 +64,13 @@ class TestTomlMetadata:
         # point should be a native TOML table, not a __ver_json__ wrapper
         assert isinstance(data["point"], dict)
         assert "__ver_json__" not in data["point"]
-        assert data["point"]["object"] == "Inner"
+        assert data["point"]["__versionable__"]["object"] == "Inner"
         assert data["point"]["x"] == 1.0
 
-        # Verify [point] section appears in the raw text
+        # Verify [point] and the wrapped envelope sub-table appear in the raw text
         text = p.read_text()
         assert "[point]" in text
+        assert "[point.__versionable__]" in text
 
     def test_humanReadable(self, tmp_path: Path) -> None:
         """TOML output should be readable text."""
@@ -122,7 +123,7 @@ class TestTomlCommentDefaults:
         assert loaded.retries == 3
 
     def test_nestedSectionHeadersNotCommented(self, tmp_path: Path) -> None:
-        """Nested Versionable section headers and their __meta__ stay uncommented."""
+        """Nested Versionable section headers and their __versionable__ sub-tables stay uncommented."""
         obj = WithNested(name="test", point=Inner(x=1.0, y=2.0))
         p = tmp_path / "out.toml"
         versionable.save(obj, p, commentDefaults=True)
@@ -131,7 +132,9 @@ class TestTomlCommentDefaults:
         # Section headers must never be commented
         assert "[point]" in text
         assert "# [point]" not in text
-        # __meta__ values within nested sections must never be commented
+        # The nested envelope sub-table and its keys must never be commented
+        assert "[point.__versionable__]" in text
+        assert "# [point.__versionable__]" not in text
         assert 'object = "Inner"' in text
         assert "# object" not in text
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -231,7 +231,7 @@ class TestNdarray:
         arr = np.array([1.0, 2.0, 3.0], dtype=np.float64)
         serialized = serialize(arr, np.ndarray)
         assert isinstance(serialized, dict)
-        assert serialized["__ndarray__"] is True
+        assert serialized["__ver_ndarray__"] is True
         result = deserialize(serialized, np.ndarray)
         np.testing.assert_array_equal(result, arr)
 
@@ -268,7 +268,7 @@ class TestNestedVersionable:
         pt = Point(x=1.0, y=2.0)
         serialized = serialize(pt, Point)
         assert isinstance(serialized, dict)
-        assert serialized["__OBJECT__"] == "Point"
+        assert serialized["object"] == "Point"
         assert serialized["x"] == 1.0
 
         result = deserialize(serialized, Point)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -268,7 +268,7 @@ class TestNestedVersionable:
         pt = Point(x=1.0, y=2.0)
         serialized = serialize(pt, Point)
         assert isinstance(serialized, dict)
-        assert serialized["object"] == "Point"
+        assert serialized["__versionable__"]["object"] == "Point"
         assert serialized["x"] == 1.0
 
         result = deserialize(serialized, Point)

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -42,9 +42,9 @@ class TestYamlMetadata:
         data = yaml.safe_load(p.read_text())
         assert "__versionable__" in data
         meta = data["__versionable__"]
-        assert meta["__OBJECT__"] == "SimpleConfig"
-        assert meta["__VERSION__"] == 1
-        assert "__HASH__" in meta
+        assert meta["object"] == "SimpleConfig"
+        assert meta["version"] == 1
+        assert "hash" in meta
 
     def test_humanReadable(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test")
@@ -144,7 +144,7 @@ class TestYamlMissingVersion:
         p.write_text("name: test\ndebug: false\nretries: 3\n")
         with caplog.at_level("WARNING"):
             versionable.load(SimpleConfig, p)
-        assert "No __VERSION__" in caplog.text
+        assert "No version" in caplog.text
         assert "SimpleConfig" in caplog.text
 
     def test_assumeVersionOverride(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -154,7 +154,7 @@ class TestYamlMissingVersion:
         with caplog.at_level("WARNING"):
             loaded = versionable.load(SimpleConfig, p, assumeVersion=1)
         assert loaded.name == "test"
-        assert "No __VERSION__" not in caplog.text
+        assert "No version" not in caplog.text
 
 
 class TestYamlLiteral:
@@ -170,7 +170,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -184,7 +184,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteral", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -198,7 +198,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteralNoValidation", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteralNoValidation", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -213,7 +213,7 @@ class TestYamlLiteral:
         p.write_text(
             yaml.dump(
                 {
-                    "__versionable__": {"__OBJECT__": "WithLiteralFallback", "__VERSION__": 1, "__HASH__": ""},
+                    "__versionable__": {"object": "WithLiteralFallback", "version": 1, "hash": ""},
                     "name": "test",
                     "mode": "banana",
                 }
@@ -245,9 +245,9 @@ class TestYamlErrors:
             yaml.dump(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
+                        "object": "SimpleConfig",
+                        "version": 1,
+                        "hash": "",
                     },
                     "debug": True,
                     "retries": 5,
@@ -267,9 +267,9 @@ class TestYamlErrors:
             yaml.dump(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 999,
-                        "__HASH__": "",
+                        "object": "SimpleConfig",
+                        "version": 999,
+                        "hash": "",
                     },
                     "name": "test",
                 }
@@ -284,10 +284,10 @@ class TestYamlErrors:
             yaml.dump(
                 {
                     "__versionable__": {
-                        "__OBJECT__": "SimpleConfig",
-                        "__VERSION__": 1,
-                        "__HASH__": "",
-                        "__FORMAT__": 2,
+                        "object": "SimpleConfig",
+                        "version": 1,
+                        "hash": "",
+                        "format": 2,
                     },
                     "name": "test",
                 }

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -73,6 +73,23 @@ class TestYamlMetadata:
         text = p.read_text()
         assert "name: test" in text
 
+    def test_nestedHasWrappedEnvelope(self, tmp_path: Path) -> None:
+        """Nested Versionable values get their own ``__versionable__`` envelope."""
+        from .conftest import Inner, WithNested
+
+        obj = WithNested(name="origin", point=Inner(x=1.0, y=2.0))
+        p = tmp_path / "out.yaml"
+        versionable.save(obj, p)
+
+        data = yaml.safe_load(p.read_text())
+        assert data["__versionable__"]["object"] == "WithNested"
+        assert "__versionable__" in data["point"]
+        assert data["point"]["__versionable__"]["object"] == "Inner"
+        assert "object" not in data["point"]
+        loaded = versionable.load(WithNested, p)
+        assert loaded.point.x == 1.0
+        assert loaded.point.y == 2.0
+
 
 class TestYamlSkipDefaults:
     def test_defaultsOmitted(self, tmp_path: Path) -> None:

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -8,9 +8,19 @@ import pytest
 
 yaml = pytest.importorskip("yaml")
 
+from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    import numpy as np
+    import numpy.typing as npt
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
 import versionable
+from versionable._base import Versionable
 from versionable.errors import BackendError, ConverterError, VersionError
 
 from .conftest import (
@@ -21,6 +31,15 @@ from .conftest import (
     WithLiteralNoValidation,
     WithSkipDefaults,
 )
+
+if _HAS_NUMPY:
+
+    @dataclass
+    class _YamlArrLegacy(Versionable, version=1, name="YamlArrLegacy", register=True):
+        """Test class for back-compat ndarray reads in YAML files."""
+
+        label: str
+        data: npt.NDArray[np.float64]
 
 
 class TestYamlRoundTrip:
@@ -295,3 +314,69 @@ class TestYamlErrors:
         )
         with pytest.raises(BackendError, match="Upgrade versionable"):
             versionable.load(SimpleConfig, p)
+
+
+class TestYamlBackCompat:
+    """Read-side compatibility for files written by versionable 0.1.x."""
+
+    def test_loadOldFormatEnvelope(self, tmp_path: Path) -> None:
+        """A file with the legacy __OBJECT__/__VERSION__/__HASH__ keys still loads."""
+        p = tmp_path / "old.yaml"
+        p.write_text(
+            yaml.dump(
+                {
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "ed3a90",
+                    },
+                    "name": "legacy",
+                    "debug": True,
+                    "retries": 7,
+                }
+            )
+        )
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.name == "legacy"
+        assert loaded.debug is True
+        assert loaded.retries == 7
+
+    def test_oldFormatFutureFormatRaises(self, tmp_path: Path) -> None:
+        """The legacy __FORMAT__ key still triggers the upgrade-required error."""
+        p = tmp_path / "old_future.yaml"
+        p.write_text(
+            yaml.dump(
+                {
+                    "__versionable__": {
+                        "__OBJECT__": "SimpleConfig",
+                        "__VERSION__": 1,
+                        "__HASH__": "",
+                        "__FORMAT__": 2,
+                    },
+                    "name": "test",
+                }
+            )
+        )
+        with pytest.raises(BackendError, match="Upgrade versionable"):
+            versionable.load(SimpleConfig, p)
+
+    @pytest.mark.skipif(not _HAS_NUMPY, reason="numpy not installed")
+    def test_loadOldFormatNdarray(self, tmp_path: Path) -> None:
+        """A file with the legacy __json__ wrapper and __ndarray__ sentinel loads."""
+        obj = _YamlArrLegacy(label="legacy-array", data=np.array([4.0, 5.0, 6.0], dtype=np.float64))
+        p = tmp_path / "old_arr.yaml"
+        versionable.save(obj, p)
+        # Rewrite both the envelope keys and the YAML/ndarray sentinels to legacy form.
+        text = p.read_text()
+        legacy = (
+            text.replace("object:", "__OBJECT__:")
+            .replace("version:", "__VERSION__:")
+            .replace("hash:", "__HASH__:")
+            .replace("__ver_json__:", "__json__:")
+            .replace("__ver_ndarray__", "__ndarray__")
+        )
+        p.write_text(legacy)
+
+        loaded = versionable.load(_YamlArrLegacy, p)
+        assert loaded.label == "legacy-array"
+        np.testing.assert_array_equal(loaded.data, np.array([4.0, 5.0, 6.0]))


### PR DESCRIPTION
**Description:** Drop the redundant dunders inside the `__versionable__` envelope (e.g. `__OBJECT__` → `object`)
and re-namespace the user-data sentinels with a `__ver_*__` prefix (e.g. `__ndarray__` → `__ver_ndarray__`).
Files written by 0.1.x still load throughout the 0.2.x line.

**Changes:**

- File format: `__OBJECT__`/`__VERSION__`/`__HASH__`/`__FORMAT__` → `object`/`version`/`hash`/`format` inside
  the `__versionable__` envelope; user-data sentinels gain a `__ver_*__` prefix.
- Read-side back-compat in every backend (`_json_backend`, `_yaml_backend`, `_toml_backend`, `_hdf5_backend`,
  `_hdf5_session`) and in `_types._deserializeNdarray`.
- Internal contract: `Backend.load()` now returns meta keyed by lowercase `object`/`version`/`hash`; `_api.py`
  and HDF5 consumers updated.
- New back-compat read tests per backend, including a mixed-keys precedence test and a nested-Versionable HDF5
  test with legacy attrs.
- Docs: `reference.md`, `getting-started.md`, `migrations.md`, `types.md`, `skills.md`, `backends.md`, the PR 2
  plan (`reference-handling.md`), and `examples/comment_defaults.py` updated.
- CHANGELOG entry under 0.2.0.

**Tests performed:**

- `pixi run --environment default cleanup` — green
- `pixi run --environment default pytest` — 441 passed
- New tests cover loading hand-crafted 0.1.x-style files in each of JSON/YAML/TOML/HDF5
- Mixed-keys precedence test confirms new keys win when both are present