### PR TITLE
Apply migrations and polymorphism to nested Versionables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## 0.2.0 (unreleased)
 
+- Migrations now apply recursively to nested `Versionable` values — direct fields, `list[B]` / `dict[K, B]` /
+  `tuple[B, ...]` / `set[B]` elements, and any depth of nesting. Previously migrations only ran at the root of a load,
+  so nested data with a schema change between save and load failed (or silently corrupted) at deserialize time. Each
+  nested file version is migrated against its own class's `Migrate` chain; a newer nested version raises `VersionError`
+  identifying the type.
+- Polymorphism is preserved across save/load: `list[Animal]` saved with `Dog` and `Cat` subclass instances reconstructs
+  as a list of the original subclass types. The per-element envelope's `object` name drives class lookup in the global
+  registry. Unknown names or wrong-subclass mismatches raise `BackendError` identifying the nested type. Combines with
+  migrations and `old_names`: each subclass migrates against its own chain, and old files referencing renamed subclasses
+  load via `old_names`.
+- `unknown="error"` / `"ignore"` / `"preserve"` now applies at every nesting level — each nested class's setting governs
+  its own field data, mirroring root behavior.
+- The class-level `validate_literals` setting is now honored at every nesting level — each nested class's declaration
+  governs its own Literal fields independently of any enclosing class. Previously `validate_literals` was silently
+  ignored on nested values.
+- **Breaking change:** removed the `validateLiterals` kwarg from `versionable.load()`. The class-level
+  `validate_literals=False` (or `literalFallback("...")` for individual fields) covers the cases the load-time override
+  addressed; the override turned out to be redundant once the class-level setting actually reached nested boundaries.
+- Save-side guard: `dict[Versionable, X]` now raises `ConverterError` at save time. Dict keys can't carry envelope
+  information and previously round-tripped as Python repr strings.
+- `versionable.load(..., upgradeInPlace=True)` is now actually honored. Previously the flag was accepted but silently
+  dropped at the root migration call, so `requiresUpgrade()` migrations always raised `UpgradeRequiredError`. The flag
+  now reaches both root and nested migrations.
 - Cycles in object graphs now raise `CircularReferenceError` at save time, with the field path of the revisit, instead
   of `RecursionError`. Detection covers all four backends (JSON, YAML, TOML, HDF5).
 - Shared references are still duplicated on save and load as separate instances. Lossless shared-reference support (and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # versionable
 
 <p align="center">
-  <img src="docs/images/logo-horizontal-tagline.svg" alt="versionable logo"/>
+  <img src="docs/images/logo-horizontal-tagline.svg" alt="versionable - future proof data files"/>
 </p>
 
 Future-proof your data files. Save structured Python objects with versioning, declarative migrations, and open file

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -271,3 +271,94 @@ class WorkerConfig(Versionable, version=3, hash="beb912"):
 
 `MigrationContext` behaves like a mutable dict over the raw deserialized data. Read and write fields by key; call
 `ctx.drop(key)` to remove a field that was deleted in the new version.
+
+## Nested Migrations
+
+Migrations apply at **every** level of the object graph, not just the root. A `Versionable` value appearing as a direct
+field, a list/dict/tuple/set element, or a nested field of a nested field gets migrated using its own class's `Migrate`
+chain when its file version differs from the class's current version.
+
+```python
+@dataclass
+class Address(Versionable, version=2, hash="..."):
+    street: str  # renamed from "addr"
+    city: str
+
+    class Migrate:
+        v1 = Migration().rename("addr", "street")
+
+@dataclass
+class Person(Versionable, version=1, hash="..."):
+    name: str
+    addresses: list[Address]
+```
+
+Loading a file saved with `Address` v1 inside a `Person` reads each nested address's envelope, applies
+`Address.Migrate.v1`, then deserializes the migrated fields. The same applies through any level — a nested field of a
+nested field migrates just as smoothly.
+
+Migration recursion works for direct fields, `list[B]`, `dict[K, B]`, `tuple[B, ...]`, and `set[B]` (where `B` is
+hashable). Each element gets its own envelope read and migration step.
+
+A few corner cases:
+
+- **Newer nested version.** If the file's nested version exceeds the class's current version, `load()` raises
+  `VersionError` identifying the nested type. (The framework can't downgrade.)
+- **Missing nested envelope.** If a nested data dict has no envelope at all (e.g., a hand-crafted file or an older
+  format), `load()` logs a warning naming the nested type and assumes the class's current version.
+- **Imperative migrations** (`@migration`-decorated functions) work at every nested level, the same way declarative
+  `Migration` objects do.
+
+## Polymorphic Collections
+
+`list[Animal]` saved with subclass instances — `Dog`, `Cat` — round-trips with subclass identity preserved. The
+per-element envelope's `object` name drives class lookup at load time:
+
+```python
+@dataclass
+class Animal(Versionable, version=1, hash="..."):
+    name: str
+
+@dataclass
+class Dog(Animal, version=1, hash="..."):
+    breed: str
+
+@dataclass
+class Cat(Animal, version=1, hash="..."):
+    indoor: bool
+
+@dataclass
+class Zoo(Versionable, version=1, hash="..."):
+    animals: list[Animal]
+
+zoo = Zoo(animals=[Dog(name="Rex", breed="lab"), Cat(name="Whiskers", indoor=True)])
+versionable.save(zoo, "zoo.json")
+
+loaded = versionable.load(Zoo, "zoo.json")
+assert isinstance(loaded.animals[0], Dog)  # subclass preserved
+assert loaded.animals[0].breed == "lab"
+```
+
+The resolver looks the per-element `object` name up in the global registry (the same one used by `loadDynamic`). Two
+error cases:
+
+- **Unknown name.** The file's `object` is not in the registry → `BackendError`. Common cause: the class was deleted or
+  renamed without `old_names`.
+- **Wrong subclass.** The resolved class is registered but is not a subclass of the declared field type →
+  `BackendError`. The file is malformed or you're loading the wrong file.
+
+Both errors identify the nested type and the declared field type so the failure points at the right place.
+
+`old_names` works across polymorphism, too: rename `Dog` to `Puppy` with `old_names=["Dog"]`, and old files with
+`object="Dog"` resolve to the new class. Each subclass migrates against its own `Migrate` chain — `Dog`'s migration runs
+for `Dog` elements, `Cat`'s for `Cat` elements.
+
+### Limitations
+
+- **Polymorphic dict keys.** `dict[Animal, X]` is rejected at save time with `ConverterError`. Dict keys serialize via
+  `str(k)` and can't carry envelope information; use `Animal` as a dict value, not a key.
+- **`register=False` polymorphism.** Polymorphism resolves the per-element envelope's `object` name through the global
+  registry. If a concrete subclass opts out with `register=False`, the resolver can't find it: when the saved name
+  differs from the declared field type, `load()` raises `BackendError`. The only `register=False` case that loads
+  cleanly is when the saved name exactly matches the declared field type (i.e. no polymorphism is actually needed).
+  Polymorphism through a base class field requires every concrete subclass to be registered.

--- a/docs/plans/nested-migrations.md
+++ b/docs/plans/nested-migrations.md
@@ -1,0 +1,461 @@
+[//]: # (vim: set ft=markdown:)
+
+# Nested Migrations and Polymorphic Deserialize
+
+- **Created:** 2026-05-01
+- **Last updated:** 2026-05-01
+- **Status:** In progress
+- **Branch:** `feature/nested-migrations`
+- **Targets release:** 0.2.0
+
+## Problem
+
+Two related correctness bugs in nested deserialize, both hidden today by the lack of nested-migration and
+nested-polymorphism test coverage:
+
+**1. Migrations don't recurse.** Migrations are applied only at the **root** of a load. A nested `Versionable`
+value (e.g. `B` at field `A.point`, or each element of `list[B]`, or values of `dict[K, B]`) is deserialized
+via `_types.py::_deserializeVersionable` using the **current** schema, with no migration step. If `B`'s schema
+has changed between save time and load time, the nested data fails to deserialize — or worse, silently
+corrupts because field names happen to line up.
+
+**2. Polymorphism doesn't work.** `_deserializeVersionable(data, cls)` always constructs `cls`, ignoring the
+envelope's `object` name. So `list[Animal]` saved with `Dog` and `Cat` elements round-trips as a list of
+`Animal` instances — the subclass identity is lost. Save records `object="Dog"` correctly; load just doesn't
+honor it.
+
+These two bugs interact. Fixing migrations alone would make polymorphism *worse* — `Animal.Migrate` would run
+on data that was saved with `Dog`'s schema. So they're fixed together: the deserializer resolves the actual
+class from the envelope's `object` first, then runs that class's migrations.
+
+### Empirical demonstration
+
+```python
+from dataclasses import dataclass
+from pathlib import Path
+import tempfile
+import versionable
+from versionable import Versionable, Migration
+from versionable._base import _REGISTRY
+
+with tempfile.TemporaryDirectory() as td:
+    p = Path(td) / "data.yaml"
+
+    @dataclass
+    class B_v1(Versionable, version=1, name="NestedTest", register=True):
+        title: str
+
+    @dataclass
+    class A_v1(Versionable, version=1, name="Container", register=True):
+        items: list[B_v1]
+
+    versionable.save(A_v1(items=[B_v1(title="hello"), B_v1(title="world")]), p)
+
+    _REGISTRY.pop("NestedTest", None)
+    _REGISTRY.pop("Container", None)
+
+    @dataclass
+    class B_v2(Versionable, version=2, name="NestedTest", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class A_v1_with_v2_B(Versionable, version=1, name="Container", register=True):
+        items: list[B_v2]
+
+    print(versionable.load(A_v1_with_v2_B, p))
+```
+
+Today this raises `TypeError: B_v2.__init__() missing 1 required positional argument: 'name'`. After this PR,
+it prints `A_v1_with_v2_B(items=[B_v2(name='hello'), B_v2(name='world')])` (dataclass `__repr__` uses the
+Python class name; the serializer's `name="Container"` is what's stored in the file envelope).
+
+## Goal
+
+For every nested `Versionable` encountered during deserialize:
+
+1. Read the envelope from the data dict.
+2. **Resolve the actual class** from the envelope's `object` name (polymorphism). Falls back to the declared
+   field type when the envelope has no object name or the envelope name matches the declared class.
+3. Extract the source version.
+4. If `fileVersion < actualCls.version`: apply migrations on `actualCls` from `fileVersion` to
+   `actualCls.version`, then deserialize fields.
+5. If `fileVersion > actualCls.version`: raise `VersionError` identifying the nested type.
+6. If `fileVersion == actualCls.version`: deserialize as today (no migration step).
+7. If envelope is missing: log a warning and assume the current version of the declared type.
+
+## Design
+
+### Where the recursion lives
+
+Inside `_deserializeVersionable(data, cls)` in `src/versionable/_types.py`. Every nested `Versionable` —
+direct field, list/tuple/set element, dict value — funnels through this function via
+`_deserializeConcrete` (see `_types.py:464-465`). Centralizing migration + polymorphism logic here covers
+the entire nested space without touching `_deserializeSequence` / `_deserializeDict`.
+
+### Polymorphic class resolution
+
+`_deserializeVersionable(data, cls)` accepts a *declared* type `cls`. The actual class to construct is
+derived from the envelope's `object` name plus `cls`:
+
+```python
+def _resolveNestedClass(envelope: dict[str, Any], cls: type[Versionable]) -> type[Versionable]:
+    """Resolve the concrete class for a nested deserialize using the envelope's object name."""
+    objectName = envelope.get("object")
+    declaredName = cls._serializer_meta_.name if hasattr(cls, "_serializer_meta_") else cls.__name__
+
+    # Back-compat: missing envelope or no object key — fall back to declared type
+    if not objectName:
+        return cls
+
+    # Same name — declared type is the right one (handles register=False classes)
+    if objectName == declaredName:
+        return cls
+
+    # Look up in registry
+    fromRegistry = _REGISTRY.get(objectName)
+    if fromRegistry is None:
+        raise BackendError(
+            f"Unknown nested object type {objectName!r}. "
+            f"Class is not registered or has been removed."
+        )
+
+    if not issubclass(fromRegistry, cls):
+        raise BackendError(
+            f"Nested object type {objectName!r} resolves to {fromRegistry.__qualname__}, "
+            f"which is not a subclass of declared type {cls.__qualname__}."
+        )
+
+    return fromRegistry
+```
+
+Resolution rules:
+
+| Condition                                                  | Result                                                |
+| ---------------------------------------------------------- | ----------------------------------------------------- |
+| Envelope has no `object` (or envelope missing entirely)    | Use declared `cls` (back-compat with envelope-less)   |
+| `object` matches `cls`'s registered name                   | Use `cls` (handles `register=False`)                  |
+| `object` is in `_REGISTRY` and resolves to a subclass of `cls` | Use the resolved class                            |
+| `object` is in `_REGISTRY` but not a subclass of `cls`     | `BackendError` (file has wrong type)                  |
+| `object` is not in `_REGISTRY` and doesn't match `cls`     | `BackendError` (unknown type)                         |
+
+Subclasses still load correctly when no polymorphism is involved (`object == cls.name`). The `old_names`
+mechanism is honored automatically: a renamed class registers itself under both its current and old names,
+so a lookup for the old name finds the current class.
+
+### Reading the nested envelope
+
+The data dict for a nested Versionable can have its envelope in three shapes:
+
+1. **Wrapped (current 0.2.0+):** `data["__versionable__"] = {"object": ..., "version": N, "hash": ...}`
+2. **Flat new keys (transient, not emitted on disk):** `data` has top-level `"object"`, `"version"`, `"hash"`.
+3. **Flat dunder keys (0.1.x files):** `data` has top-level `"__OBJECT__"`, `"__VERSION__"`, `"__HASH__"`.
+
+A small helper extracts the version (and object/hash for diagnostics) regardless of shape:
+
+```python
+def _readNestedEnvelope(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract version/object/hash from a nested Versionable's data dict."""
+    if isinstance(data.get("__versionable__"), dict):
+        envelope = data["__versionable__"]
+    else:
+        envelope = data
+    return {
+        "object": envelope.get("object", envelope.get("__OBJECT__")),
+        "version": envelope.get("version", envelope.get("__VERSION__")),
+        "hash": envelope.get("hash", envelope.get("__HASH__")),
+    }
+```
+
+### Strip-then-migrate-then-deserialize
+
+`applyMigrations(data, migrations)` operates on field-name keys. The data dict passed to a nested
+deserializer also contains envelope keys. We strip envelope keys before migration:
+
+```python
+_ENVELOPE_KEYS = frozenset({"__versionable__", "__OBJECT__", "__VERSION__", "__HASH__",
+                            "object", "version", "hash", "__FORMAT__", "format"})
+
+# In _deserializeVersionable (sketch):
+fileVersion = _readNestedEnvelope(data)["version"]
+meta = cls._serializer_meta_
+if fileVersion is None:
+    logger.warning(...)  # missing nested envelope
+    fields = _stripEnvelope(data)
+elif fileVersion < meta.version:
+    fields = _stripEnvelope(data)
+    fields = _applyMigrations(cls, fields, fileVersion, meta.version)
+elif fileVersion > meta.version:
+    raise VersionError(f"Nested {meta.name}: file version {fileVersion} > class version {meta.version}.")
+else:
+    fields = _stripEnvelope(data)
+# continue with the existing deserialize loop, using `fields` instead of `data`
+```
+
+The strip predicate uses an explicit allow-list (the keys above) — not a `startswith("__")` check —
+because user data fields can technically begin with underscores even though `_resolveFields` already
+filters them out at the dataclass level.
+
+### Lazy field interaction (HDF5)
+
+`_deserializeVersionable` pops `__ver_lazy__` early. Migration runs *after* the lazy pop, so lazy
+sentinels are not exposed to migration ops. Lazy array migrations are out of scope (the array data
+isn't loaded yet); the dataclass field holding the lazy sentinel still gets migrated like any other
+field name.
+
+### `assumeVersion` interaction
+
+`assumeVersion` at `versionable.load(...)` only applies to the root. For nested elements with
+missing envelopes, log a warning and assume the current class version. Different classes have
+different version spaces; threading `assumeVersion` through nesting would conflate them. Document
+this in the `versionable.load` docstring and `migrations.md`.
+
+### Imperative migrations
+
+`_applyMigrations` already handles both `Migration` and `_ImperativeMigration`. No special handling
+needed at the nested layer — confirm via test.
+
+### `validate_literals` at every nesting level (breaking change)
+
+Today, `validate_literals` is declared per class but only honored at the root: nested
+`_deserializeVersionable` ignores `cls.meta.validateLiterals` entirely. Worse, the load-time
+override `versionable.load(..., validateLiterals=False)` doesn't reach nested Versionables either.
+
+Fix: collapse to one mechanism. The class-level setting is the single source of truth. Each
+`_deserializeVersionable` reads its own `cls.meta.validateLiterals` and propagates it as a plain
+`bool` to its own field deserialization. When a nested Versionable boundary is crossed (via
+`_deserializeConcrete`), the inherited bool is dropped — the nested class re-reads its own
+setting. Result: each class's `validate_literals` declaration governs its own Literal fields,
+independently of any enclosing class.
+
+**Breaking change:** the `validateLiterals` keyword on `versionable.load()` is removed.
+Pre-1.0 — the existing escape hatches cover the use cases:
+
+- For a single field with a known fallback value: `mode: Literal["fast", "slow"] = literalFallback("fast")`.
+- For a class that should never validate: declare it with `validate_literals=False`.
+
+Removing the parameter means **no `bool | None` plumbing, no `_classFallback` second parameter,
+no two-stage resolution**. `deserialize` and friends carry just `validateLiterals: bool = True`,
+seeded by each `_deserializeVersionable` from its own class's setting.
+
+### `upgradeInPlace` propagation
+
+Today `versionable.load(..., upgradeInPlace=True)` is accepted but never reaches
+`applyMigrations`. A migration that uses `requiresUpgrade()` raises `UpgradeRequiredError` even
+when the caller passed `upgradeInPlace=True` — the flag is silently dropped at the root, and the
+nested deserialize path doesn't even see it.
+
+Fix: forward the load-time flag to `applyMigrationRange` at the root, and thread it through the
+deserialize chain (`deserialize` → `_deserializeConcrete` → `_deserializeSequence` /
+`_deserializeDict` / `_deserializeUnion` → `_deserializeVersionable`) so nested `requiresUpgrade()`
+ops honor the same flag. Unlike `validateLiterals` (which has a class-level alternative),
+`upgradeInPlace` is genuinely a load-time global with no per-class equivalent — plumbing it through
+is the right design.
+
+The flag's semantics are unchanged: `True` suppresses `UpgradeRequiredError` so the caller can
+proceed (e.g., to perform the file rewrite themselves); `False` raises the error so a careless
+load doesn't silently mutate files the caller didn't intend to modify.
+
+### Unknown-field handling at nested level
+
+Today `unknown="error"`, `"ignore"`, `"preserve"` are only honored at the root.
+`_deserializeVersionable` ignores them — extra fields in nested data are silently dropped (because
+field iteration only pulls declared names). Fix: after migration, compute the unknown set against
+the resolved class's fields and apply the same root-level policy:
+
+```python
+unknownFields = set(fields_dict.keys()) - knownFieldNames
+if unknownFields:
+    if meta.unknown == "error":
+        raise UnknownFieldError(f"Unknown fields in nested {meta.name}: {sorted(unknownFields)}")
+    if meta.unknown == "ignore":
+        for name in unknownFields:
+            del fields_dict[name]
+    # "preserve" mode: leave them; field iteration won't pick them up
+```
+
+Each nested class's own `unknown` setting governs its own data.
+
+### Save-side guard: no Versionable dict keys
+
+Polymorphism at dict *values* is supported (`dict[str, Animal]` works). Polymorphism at dict
+*keys* (`dict[Animal, str]`) is not — keys serialize via `str(k)` (see `_types.py:311`), which
+silently produces a Python repr for Versionable instances and round-trips incorrectly. Today this
+fails confusingly on load. After this PR, `serialize()` raises `ConverterError` at save time when
+a dict key type is a Versionable subclass:
+
+```python
+if isinstance(value, dict):
+    keyType = args[0] if args else Any
+    if isinstance(keyType, type) and issubclass(keyType, Versionable):
+        raise ConverterError(
+            f"Dict keys cannot be Versionable types ({keyType.__name__}). "
+            f"Use Versionable as dict values, not keys."
+        )
+    ...
+```
+
+## Touchpoints
+
+### Source
+
+| File                      | What                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `_types.py`               | `_readNestedEnvelope`, `_stripEnvelope`, `_resolveNestedClass`, polymorphism + migration + unknown-field handling in `_deserializeVersionable`. `validateLiterals: bool = True` and `upgradeInPlace: bool = False` carried through `_deserializeConcrete`/`_deserializeSequence`/`_deserializeDict`/`_deserializeUnion`. `validateLiterals` is seeded by each `_deserializeVersionable` from its class's `meta.validateLiterals`; `upgradeInPlace` propagates unchanged from the root `load(...)` call. Save-side dict-key Versionable guard. |
+| `_api.py`                 | Move `_applyMigrations` to `_migration.py`. Drop `validateLiterals` kwarg from `load()`. Forward `upgradeInPlace` to both the root `applyMigrationRange` call and the nested `deserialize` calls. |
+| `_migration.py`           | Receives the moved `_applyMigrations` helper.                              |
+
+`_applyMigrations` currently lives in `_api.py` and imports from `_migration`. `_types.py` cannot
+import from `_api.py` (circular — `_api.py` already imports `deserialize` from `_types.py`).
+Cleanest fix: move the helper to `_migration.py` (which has no `_types.py` dependency), then import
+it from both `_api.py` and `_types.py`.
+
+### Tests
+
+New file: `tests/test_nested_migrations.py`. Existing `tests/test_migration.py` is root-only — keep
+unchanged.
+
+### Docs
+
+| File              | Change                                                                       |
+| ----------------- | ---------------------------------------------------------------------------- |
+| `migrations.md`   | New "Nested migrations" section explaining recursion at every level.         |
+| `reference.md`    | Note in the deserialize/load reference that migrations apply recursively.    |
+| `CHANGELOG.md`    | 0.2.0 entry: nested migrations + missing-envelope warning behavior.          |
+
+## Test matrix
+
+Place all tests in `tests/test_nested_migrations.py`. Use snake_case identifiers per project
+convention. Hardcode hashes as string literals (compute once via `MyClass.hash()` in a REPL, then
+paste).
+
+### Migration recursion
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 1 | Single-field nested: `A.point: B`, save B-v1, load B-v2 + rename migration | JSON, YAML, TOML, HDF5 |
+| 2 | `list[B]` element migrations | JSON |
+| 3 | `dict[str, B]` value migrations | JSON |
+| 4 | `tuple[B, ...]` element migrations | JSON |
+| 5 | `set[B]` element migrations (use hash-stable `B`) | JSON |
+| 6 | Multi-step chain at nested level: B v1 → v2 → v3 | JSON |
+| 7 | Both parent and child migrated: A-v1 → A-v2 + B-v1 → B-v2 | JSON |
+| 8 | Newer nested version raises `VersionError` mentioning the nested type | JSON |
+| 9 | Missing nested envelope: logs a warning, assumes current version | JSON |
+| 10 | Imperative `@migration` decorator on nested type | JSON |
+| 11 | Three-level deep migration: A.b: B, B.c: C, all at v1 → all at v2 | JSON |
+| 12 | Cross-backend: save YAML at v1, load TOML at v2 | YAML → TOML |
+| 13 | Nested migration on HDF5 (covers the `loadLazy` path) | HDF5 |
+
+### Polymorphism
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 14 | `list[Animal]` saved with `[Dog, Cat]` round-trips with subclass identity preserved | JSON, HDF5 |
+| 15 | Polymorphism + migration: `Dog` v1 → v2 applied, `Cat` v1 → v2 applied | JSON |
+| 16 | Unknown nested object name raises `BackendError` | JSON |
+| 17 | Resolved class is not a subclass of declared type → `BackendError` | JSON |
+| 18 | `old_names` covers polymorphism rename: file says `object="OldDog"`, current class registers `name="Dog", old_names=["OldDog"]` | JSON |
+
+### Save-side guards
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 19 | Saving `dict[Versionable, X]` raises `ConverterError` | (save side; backend-agnostic) |
+
+### `validate_literals` at nested level
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 20a | Default behavior: nested class with default `validate_literals=True` validates its Literals | JSON |
+| 20b | Nested class with `validate_literals=False` honored independently of parent's setting | JSON |
+
+### Unknown-field handling at nested
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 21 | Nested class with `unknown="error"` raises `UnknownFieldError` on extra field | JSON |
+| 22 | Nested class with `unknown="ignore"` silently drops extras | JSON |
+
+### `upgradeInPlace` propagation
+
+| # | Scenario | Backends |
+|---|----------|----------|
+| 23 | `load(..., upgradeInPlace=True)` suppresses `UpgradeRequiredError` for a `requiresUpgrade()` op at the root | JSON |
+| 24 | `load(..., upgradeInPlace=True)` reaches a `requiresUpgrade()` op on a nested Versionable | JSON |
+
+JSON is the representative backend for tests where dispatch is backend-agnostic; the per-backend
+coverage in tests 1, 12, 13, 14 confirms each backend delivers nested envelopes in a shape the
+recursion can read.
+
+## Backwards compatibility
+
+- 0.1.x files with **flat dunder envelopes** at the nested level continue to load — the envelope
+  reader handles all three shapes.
+- 0.1.x files with **no nested envelope** (pre-envelope-keys format, or hand-crafted) load with a
+  warning and assume the current version. This matches root-level behavior. No file in the wild
+  should be affected — 0.1.x files always wrote envelopes.
+- Existing root-only migration tests (`tests/test_migration.py`) continue to pass unchanged.
+
+## Acceptance
+
+- `pixi run --environment default cleanup && pixi run --environment default pytest` green.
+- The empirical demonstration above prints
+  `A_v1_with_v2_B(items=[B_v2(name='hello'), B_v2(name='world')])` instead of raising `TypeError`.
+- Test matrix above is covered.
+- Plan doc committed at `docs/plans/nested-migrations.md`.
+- `CHANGELOG.md` 0.2.0 entry mentions nested migrations, polymorphism, the
+  `validate_literals` consolidation (breaking: removed `validateLiterals` kwarg from `load()`),
+  nested unknown-field handling, and the dict-keys save-side guard.
+- `docs/migrations.md` and `docs/reference.md` updated to state migrations and polymorphism apply
+  recursively.
+
+## Risk
+
+Medium. The change touches the central deserialize loop, which is exercised by every
+`load()` call across all backends. Mitigations:
+
+- Test matrix covers each backend separately at the nested level.
+- The fast path (file version equals class version, envelope object matches declared type) is
+  unchanged: same field iteration, same envelope-key skipping. Only the migration and polymorphism
+  branches are new.
+- Strip-and-migrate is keyed off explicit envelope key names, not heuristics.
+- Polymorphism resolution falls back to the declared type when the envelope is missing or matches
+  the declared name — pre-existing files keep loading.
+
+## Out of scope
+
+- **Load-time hash validation.** Today the file's recorded hash is read into `fileMeta` but never
+  compared to the class's hash. Adding it (uniformly at root and nested) is a separate hardening.
+- **Polymorphic dict keys** (`dict[Animal, str]`). Save raises `ConverterError` (in scope for this
+  PR — see save-side guard above), but the underlying support is not added: dict keys serialize
+  via `str(k)` and don't carry envelope information.
+- **`assumeVersion` propagation to nested.** Different classes have different version spaces;
+  threading one int through doesn't compose. Nested missing-envelope falls back to the resolved
+  class's current version with a warning.
+- **Polymorphism for `register=False` classes.** Without registry presence, the resolver can't
+  find the class by name. The declared field type is used as a fallback only when names match.
+  Documented as a limitation in `migrations.md`.
+- **Polymorphism rename without `old_names`.** Old files with the previous name produce
+  `BackendError` (clear failure, not silent corruption). Documented as a limitation.
+- **The envelope-deduplication optimization** tracked in #28.
+- **HDF5 native lazy array migrations.** Lazy fields aren't loaded at load time, so migrating
+  their values doesn't apply. The dataclass field holding the lazy sentinel still gets migrated
+  like any other field name.
+
+## Suggested commit order
+
+1. Plan doc (this file).
+2. Implementation: move `_applyMigrations` to `_migration.py`; add envelope helpers,
+   polymorphism resolver, migration call, nested unknown-field handling, and the save-side
+   `dict[Versionable, X]` guard in `_types.py`. Drop the `validateLiterals` kwarg from
+   `load()`; carry `validateLiterals: bool = True` through the deserialize chain, seeded by
+   each `_deserializeVersionable` from its class's `meta.validateLiterals`. Add
+   `tests/test_nested_migrations.py`.
+3. Documentation: update `docs/migrations.md`, `docs/reference.md`, `CHANGELOG.md` (note the
+   breaking change for `validateLiterals` kwarg removal), and the README's nested-objects
+   bullet.
+4. `pixi run --environment default cleanup` — fix anything reported.
+5. Show staged diff + commit message for approval, then commit + push.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -65,6 +65,23 @@ mypackage.models.MyClass. Give one of the classes an explicit name to
 disambiguate, e.g.: class MyClass(Versionable, ..., name="other.MyClass")
 ```
 
+## Nested Deserialization
+
+When `load()` deserializes a `Versionable` field, list/dict/tuple/set element, or any value reachable from the root,
+three things happen at every level:
+
+1. **Polymorphism resolution.** The per-element envelope's `object` name is looked up in the global registry. If found
+   and the resolved class is a subclass of the declared field type, the resolved class is used — `list[Animal]` saved
+   with `Dog` and `Cat` elements reconstructs as a list of `Dog` and `Cat` instances. If the envelope is missing or the
+   name matches the declared type, the declared type is used (back-compat).
+2. **Migration.** If the file's recorded version is less than the resolved class's current version, the resolved class's
+   `Migrate` chain runs against the field data before deserialization. If newer, `load()` raises `VersionError`
+   identifying the nested type.
+3. **Unknown-field handling.** The resolved class's `unknown="error"`/`"ignore"`/`"preserve"` setting governs extra
+   fields after migration.
+
+See [migrations.md](migrations.md) for declarative and imperative migration syntax, including nested examples.
+
 ## Field Serialization Rules
 
 A field is included in serialization if it:

--- a/src/versionable/_api.py
+++ b/src/versionable/_api.py
@@ -17,6 +17,7 @@ from typing import Any, TypeVar
 
 from versionable._backend import Backend, getBackend
 from versionable._base import Versionable, _resolveFields, metadata
+from versionable._migration import applyMigrationRange
 from versionable._types import deserialize
 from versionable.errors import BackendError, UnknownFieldError, VersionError
 
@@ -93,7 +94,6 @@ def load[T: Versionable](
     metadataOnly: bool = False,
     upgradeInPlace: bool = False,
     assumeVersion: int | None = None,
-    validateLiterals: bool | None = None,
 ) -> T:
     """Load a ``Versionable`` object from *path*.
 
@@ -106,12 +106,16 @@ def load[T: Versionable](
         upgradeInPlace: If True, allow file modification during migration.
         assumeVersion: Version to assume when the file has no ``version``
             metadata.  Defaults to the class's current version.
-        validateLiterals: Whether to validate ``Literal`` type values.
-            Overrides the class-level ``validate_literals`` setting.
-            Defaults to the class setting (``True`` unless overridden).
 
     Returns:
         An instance of *cls*.
+
+    Notes:
+        ``Literal`` field validation is governed by each class's
+        ``validate_literals`` setting (default ``True``). To skip validation
+        for a specific field with a known fallback value, use
+        ``literalFallback("...")``. To disable validation for a whole class,
+        declare it with ``validate_literals=False``.
     """
     # Ensure backend module is imported so backends are registered
     _ensureBackendsRegistered()
@@ -148,7 +152,7 @@ def load[T: Versionable](
 
     # Version check — apply migrations if needed
     if fileVersion < meta.version:
-        rawFields = _applyMigrations(cls, rawFields, fileVersion, meta.version)
+        rawFields = applyMigrationRange(cls, rawFields, fileVersion, meta.version, upgradeInPlace=upgradeInPlace)
     elif fileVersion > meta.version:
         raise VersionError(
             f"File version ({fileVersion}) is newer than class version "
@@ -172,7 +176,6 @@ def load[T: Versionable](
     import dataclasses
 
     nativeTypes = be.nativeTypes
-    effectiveValidateLiterals = validateLiterals if validateLiterals is not None else meta.validateLiterals
     # Versionable subclasses are always @dataclass; mypy/pyright can't prove that statically.
     dcFields = {f.name: f for f in dataclasses.fields(cls)}  # type: ignore[arg-type]
     kwargs: dict[str, Any] = {}
@@ -190,7 +193,8 @@ def load[T: Versionable](
                     fieldType,
                     nativeTypes=nativeTypes,
                     fieldMetadata=dcMeta,
-                    validateLiterals=effectiveValidateLiterals,
+                    validateLiterals=meta.validateLiterals,
+                    upgradeInPlace=upgradeInPlace,
                 )
         # Use dataclass default
         elif fieldName in dcFields:
@@ -249,33 +253,6 @@ def loadDynamic(
         raise BackendError(f"Object type {objectName!r} is not a subclass of {baseClass.__name__}")
 
     return load(cls, path, backend=backend)
-
-
-# ---------------------------------------------------------------------------
-# Migration helpers
-# ---------------------------------------------------------------------------
-
-
-def _applyMigrations(
-    cls: type[Versionable],
-    data: dict[str, Any],
-    fromVersion: int,
-    toVersion: int,
-) -> dict[str, Any]:
-    """Apply migrations to upgrade *data* from *fromVersion* to *toVersion*.
-
-    This is a placeholder — the full migration system is implemented in
-    Phase D (_migration.py).
-    """
-    try:
-        from versionable._migration import applyMigrations, resolveMigrations
-    except ImportError:
-        raise VersionError(
-            f"File is version {fromVersion} but class is version {toVersion}. Migration system not available."
-        ) from None
-
-    migrations = resolveMigrations(cls, fromVersion, toVersion)
-    return applyMigrations(data, migrations)
 
 
 # ---------------------------------------------------------------------------

--- a/src/versionable/_migration.py
+++ b/src/versionable/_migration.py
@@ -318,6 +318,23 @@ def applyMigrations(
     return result
 
 
+def applyMigrationRange(
+    cls: type,
+    data: dict[str, Any],
+    fromVersion: int,
+    toVersion: int,
+    *,
+    upgradeInPlace: bool = False,
+) -> dict[str, Any]:
+    """Resolve and apply migrations on *cls* for the version range [fromVersion, toVersion).
+
+    Convenience wrapper around :func:`resolveMigrations` + :func:`applyMigrations` for
+    callers that have a class plus a version gap rather than a pre-resolved migration list.
+    """
+    migrations = resolveMigrations(cls, fromVersion, toVersion)
+    return applyMigrations(data, migrations, upgradeInPlace=upgradeInPlace)
+
+
 def _applyDeclarativeMigration(
     data: dict[str, Any],
     mig: Migration,

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -19,10 +19,17 @@ from enum import Enum
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Protocol, runtime_checkable
 
-from versionable._base import Versionable, _resolveFields
+from versionable._base import _REGISTRY, Versionable, _resolveFields
+from versionable._migration import applyMigrationRange
 from versionable._numpy_compat import _np as np
 from versionable._numpy_compat import requireNumpy
-from versionable.errors import CircularReferenceError, ConverterError
+from versionable.errors import (
+    BackendError,
+    CircularReferenceError,
+    ConverterError,
+    UnknownFieldError,
+    VersionError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -306,6 +313,14 @@ def _serializeCollection(
     args = typing.get_args(fieldType)
 
     if isinstance(value, dict):
+        # Reject Versionable dict keys: dict keys serialize via str(k), which would
+        # silently produce a Python repr for Versionable instances and corrupt on
+        # round-trip. Use Versionable as dict values, not keys.
+        if args and isinstance(args[0], type) and issubclass(args[0], Versionable):
+            raise ConverterError(
+                f"Dict keys cannot be Versionable types ({args[0].__name__}) at field "
+                f"{path or '<root>'}. Use Versionable as dict values, not keys."
+            )
         valType = args[1] if len(args) > 1 else Any
         return {
             str(k): serialize(
@@ -355,6 +370,7 @@ def deserialize(
     nativeTypes: set[type] | None = None,
     fieldMetadata: Any | None = None,
     validateLiterals: bool = True,
+    upgradeInPlace: bool = False,
 ) -> Any:
     """Deserialize *data* back to the declared *fieldType*.
 
@@ -363,7 +379,16 @@ def deserialize(
         fieldType: The declared type annotation for the field.
         nativeTypes: Types the backend handles natively (skip conversion).
         fieldMetadata: Optional dataclass field metadata (for literal fallbacks).
-        validateLiterals: Whether to validate Literal type values.
+        validateLiterals: Whether to validate ``Literal`` field values at the
+            current call site. The enclosing ``Versionable``'s class setting
+            governs this; it is reset at each nested ``Versionable`` boundary
+            (inside ``_deserializeVersionable``) so nested classes apply their
+            own ``meta.validateLiterals``.
+        upgradeInPlace: Forwarded to :func:`applyMigrationRange` whenever a
+            nested ``Versionable`` boundary triggers a migration. Suppresses
+            ``UpgradeRequiredError`` for ``requiresUpgrade()`` ops; the caller
+            is responsible for actually rewriting the file. Threaded through
+            unchanged from the root ``versionable.load(...)`` call.
     """
     if data is None:
         return None
@@ -395,12 +420,24 @@ def deserialize(
 
     if origin is typing.Union or _isUnionType(origin):
         return _deserializeUnion(
-            data, args, nativeTypes, fieldMetadata=fieldMetadata, validateLiterals=validateLiterals
+            data,
+            args,
+            nativeTypes,
+            fieldMetadata=fieldMetadata,
+            validateLiterals=validateLiterals,
+            upgradeInPlace=upgradeInPlace,
         )
 
     # Resolve the concrete type and dispatch
     concreteType = origin or fieldType
-    return _deserializeConcrete(data, concreteType, args, nativeTypes)
+    return _deserializeConcrete(
+        data,
+        concreteType,
+        args,
+        nativeTypes,
+        validateLiterals=validateLiterals,
+        upgradeInPlace=upgradeInPlace,
+    )
 
 
 def _deserializeUnion(
@@ -409,6 +446,7 @@ def _deserializeUnion(
     nativeTypes: set[type],
     fieldMetadata: Any | None = None,
     validateLiterals: bool = True,
+    upgradeInPlace: bool = False,
 ) -> Any:
     """Deserialize a Union type by trying each member."""
     nonNoneArgs = [a for a in args if a is not type(None)]
@@ -419,11 +457,17 @@ def _deserializeUnion(
             nativeTypes=nativeTypes,
             fieldMetadata=fieldMetadata,
             validateLiterals=validateLiterals,
+            upgradeInPlace=upgradeInPlace,
         )
     for arg in nonNoneArgs:
         try:
             return deserialize(
-                data, arg, nativeTypes=nativeTypes, fieldMetadata=fieldMetadata, validateLiterals=validateLiterals
+                data,
+                arg,
+                nativeTypes=nativeTypes,
+                fieldMetadata=fieldMetadata,
+                validateLiterals=validateLiterals,
+                upgradeInPlace=upgradeInPlace,
             )
         except (TypeError, ValueError, ConverterError):
             continue
@@ -435,6 +479,9 @@ def _deserializeConcrete(
     concreteType: Any,
     args: tuple[Any, ...],
     nativeTypes: set[type],
+    *,
+    validateLiterals: bool = True,
+    upgradeInPlace: bool = False,
 ) -> Any:
     """Deserialize to a concrete (non-union) type."""
     # Backend native types — pass through
@@ -460,9 +507,12 @@ def _deserializeConcrete(
     if isinstance(concreteType, type) and issubclass(concreteType, Enum):
         return _deserializeEnum(data, concreteType)
 
-    # Nested Versionable
+    # Nested Versionable — `_deserializeVersionable` reads its own
+    # `cls.meta.validateLiterals`, so the enclosing class's setting does not
+    # cross the boundary. `upgradeInPlace` does propagate (it's a load-time
+    # global, not class-scoped) so nested `requiresUpgrade()` ops honor it.
     if isinstance(concreteType, type) and issubclass(concreteType, Versionable):
-        return _deserializeVersionable(data, concreteType)
+        return _deserializeVersionable(data, concreteType, upgradeInPlace=upgradeInPlace)
 
     # numpy ndarray (both explicit ndarray and npt.NDArray alias)
     if np is not None and (
@@ -472,10 +522,14 @@ def _deserializeConcrete(
 
     # Collections
     if concreteType in (list, tuple, set, frozenset):
-        return _deserializeSequence(data, concreteType, args, nativeTypes)
+        return _deserializeSequence(
+            data, concreteType, args, nativeTypes, validateLiterals=validateLiterals, upgradeInPlace=upgradeInPlace
+        )
 
     if concreteType is dict:
-        return _deserializeDict(data, args, nativeTypes)
+        return _deserializeDict(
+            data, args, nativeTypes, validateLiterals=validateLiterals, upgradeInPlace=upgradeInPlace
+        )
 
     # Fallback
     return data
@@ -486,10 +540,22 @@ def _deserializeSequence(
     concreteType: type,
     args: tuple[Any, ...],
     nativeTypes: set[type],
+    *,
+    validateLiterals: bool = True,
+    upgradeInPlace: bool = False,
 ) -> Any:
     """Deserialize list, tuple, set, or frozenset."""
     elemType = args[0] if args else Any
-    items = [deserialize(v, elemType, nativeTypes=nativeTypes) for v in data]
+    items = [
+        deserialize(
+            v,
+            elemType,
+            nativeTypes=nativeTypes,
+            validateLiterals=validateLiterals,
+            upgradeInPlace=upgradeInPlace,
+        )
+        for v in data
+    ]
     if concreteType is tuple:
         return tuple(items)
     if concreteType is set:
@@ -503,12 +569,27 @@ def _deserializeDict(
     data: Any,
     args: tuple[Any, ...],
     nativeTypes: set[type],
+    *,
+    validateLiterals: bool = True,
+    upgradeInPlace: bool = False,
 ) -> dict[str, Any]:
     """Deserialize a dict."""
     keyType = args[0] if args else str
     valType = args[1] if len(args) > 1 else Any
     return {
-        deserialize(k, keyType, nativeTypes=nativeTypes): deserialize(v, valType, nativeTypes=nativeTypes)
+        deserialize(
+            k,
+            keyType,
+            nativeTypes=nativeTypes,
+            validateLiterals=validateLiterals,
+            upgradeInPlace=upgradeInPlace,
+        ): deserialize(
+            v,
+            valType,
+            nativeTypes=nativeTypes,
+            validateLiterals=validateLiterals,
+            upgradeInPlace=upgradeInPlace,
+        )
         for k, v in data.items()
     }
 
@@ -557,32 +638,215 @@ def _serializeVersionable(obj: Versionable, visited: set[int], path: str) -> dic
     return result
 
 
-def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Versionable:
+# ---------------------------------------------------------------------------
+# Nested envelope reading and polymorphism resolution
+# ---------------------------------------------------------------------------
+#
+# Nested ``Versionable`` data dicts can carry envelope keys in three layouts:
+#
+# 1. Wrapped (current 0.2.0+ JSON/YAML/TOML files):
+#    ``data["__versionable__"] = {"object": ..., "version": N, "hash": ...}``
+# 2. Flat new keys (current HDF5 read output, transient on the wire):
+#    ``data`` has top-level ``"object"``, ``"version"``, ``"hash"``.
+# 3. Flat dunder keys (0.1.x files):
+#    ``data`` has top-level ``"__OBJECT__"``, ``"__VERSION__"``, ``"__HASH__"``.
+#
+# ``_readNestedEnvelope`` reads any of these layouts; ``_stripEnvelope`` removes
+# all envelope keys before migrations operate on field-name keys.
+
+_ENVELOPE_KEYS = frozenset(
+    {
+        "__versionable__",
+        # Flat new (0.2.0+, current HDF5 read output)
+        "object",
+        "version",
+        "hash",
+        "format",
+        "format_be",
+        "shared_refs",
+        # Flat dunder (0.1.x file format)
+        "__OBJECT__",
+        "__VERSION__",
+        "__HASH__",
+        "__FORMAT__",
+        "__FORMAT_BE__",
+        "__SHARED_REFS__",
+    }
+)
+
+
+def _readNestedEnvelope(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract envelope fields (object, version, hash) from a nested Versionable's data dict.
+
+    Handles wrapped (``data["__versionable__"]``), flat-new (``object``/``version``/``hash``
+    at top level), and flat-dunder (``__OBJECT__``/``__VERSION__``/``__HASH__``) layouts.
+
+    Returns a dict with keys ``object``, ``version``, ``hash``. Values are ``None`` when
+    the corresponding envelope field is not present.
+    """
+    envelope = data["__versionable__"] if isinstance(data.get("__versionable__"), dict) else data
+    return {
+        "object": envelope.get("object", envelope.get("__OBJECT__")),
+        "version": envelope.get("version", envelope.get("__VERSION__")),
+        "hash": envelope.get("hash", envelope.get("__HASH__")),
+    }
+
+
+def _stripEnvelope(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *data* with envelope keys removed.
+
+    Migration ops operate on field-name keys; envelope keys (``__versionable__``,
+    ``object``/``version``/``hash``, and the legacy dunder forms) must be removed before
+    migrations run so they don't get treated as user fields.
+    """
+    return {k: v for k, v in data.items() if k not in _ENVELOPE_KEYS}
+
+
+def _resolveNestedClass(envelope: dict[str, Any], cls: type[Versionable]) -> type[Versionable]:
+    """Resolve the concrete class for a nested deserialize using the envelope's object name.
+
+    Supports polymorphic collections: ``list[Animal]`` saved with ``Dog`` and ``Cat``
+    elements is reconstructed with the original subclass identities. Falls back to
+    *cls* (the declared field type) when the envelope is missing or matches the
+    declared name, supporting back-compat and ``register=False`` classes.
+
+    Args:
+        envelope: Output of :func:`_readNestedEnvelope`.
+        cls: The declared field type (e.g., ``Animal`` for ``field: list[Animal]``).
+
+    Raises:
+        BackendError: If the envelope's ``object`` is not in the registry, or resolves
+            to a class that is not a subclass of *cls*.
+    """
+    objectName = envelope.get("object")
+    if not objectName:
+        # Missing envelope or no object key — back-compat with envelope-less data.
+        return cls
+
+    declaredName = cls._serializer_meta_.name if hasattr(cls, "_serializer_meta_") else cls.__name__
+    if objectName == declaredName:
+        # Same identity — use the declared type (also handles register=False classes
+        # whose declared type isn't in the registry).
+        return cls
+
+    fromRegistry = _REGISTRY.get(objectName)
+    if fromRegistry is None:
+        raise BackendError(
+            f"Unknown nested object type {objectName!r} (declared field type: {cls.__qualname__}). "
+            f"Class is not registered or has been removed."
+        )
+    if not issubclass(fromRegistry, cls):
+        raise BackendError(
+            f"Nested object type {objectName!r} resolves to {fromRegistry.__qualname__}, "
+            f"which is not a subclass of declared field type {cls.__qualname__}."
+        )
+    return fromRegistry
+
+
+def _deserializeVersionable(
+    data: dict[str, Any],
+    cls: type[Versionable],
+    *,
+    upgradeInPlace: bool = False,
+) -> Versionable:
     """Deserialize a dict to a Versionable instance.
 
-    If the dict contains a ``__ver_lazy__`` key (set by the HDF5 backend's
-    recursive lazy reader), lazy sentinels are passed through without
-    deserialization and the instance is wrapped with ``makeLazyInstance``.
+    Reads the per-element envelope to:
+    - Resolve the concrete class for polymorphic collections (e.g., ``list[Animal]``
+      with ``Dog`` and ``Cat`` elements preserves subclass identity).
+    - Apply migrations from the file's recorded version to the resolved class's version.
+    - Honor the resolved class's ``unknown="error"``/``"ignore"``/``"preserve"`` policy
+      against extra fields after migration.
+
+    Literal-field validation is governed by the resolved class's own
+    ``meta.validateLiterals``: each ``Versionable`` boundary re-reads its class's
+    setting before recursing into its fields, so nested classes apply their own
+    declaration independently.
+
+    If the dict contains a ``__ver_lazy__`` key (set by the HDF5 backend's recursive
+    lazy reader), lazy sentinels are passed through without deserialization and the
+    instance is wrapped with ``makeLazyInstance``.
+
+    Args:
+        data: The serialized field dict for the Versionable instance, including
+            envelope keys (any of the three supported layouts).
+        cls: The declared field type. Used as a fallback when no envelope is present
+            and as the polymorphism upper bound (``object`` must resolve to a subclass).
+        upgradeInPlace: Forwarded to :func:`applyMigrationRange` so nested
+            ``requiresUpgrade()`` migrations honor the root ``load(...)`` flag.
+
+    Raises:
+        VersionError: File version is newer than the resolved class's version.
+        BackendError: Polymorphism resolution failed (unknown name or wrong subclass).
+        UnknownFieldError: Resolved class has ``unknown="error"`` and the data
+            contains fields not declared on the class.
     """
     import dataclasses
 
     lazyFields: set[str] = data.pop("__ver_lazy__", set())
 
-    meta = cls._serializer_meta_
-    fields = _resolveFields(cls)
-    dcFields = {f.name: f for f in dataclasses.fields(cls)}  # type: ignore[arg-type]
+    # Polymorphism: resolve the concrete class from the envelope's object name.
+    envelope = _readNestedEnvelope(data)
+    actualCls = _resolveNestedClass(envelope, cls)
+    meta = actualCls._serializer_meta_
+
+    # Migration: strip envelope, then apply if file version differs.
+    fileVersion = envelope.get("version")
+    if fileVersion is None:
+        # Missing envelope (0.1.x without envelope, hand-crafted file) — assume current.
+        logger.warning(
+            "Nested %s: no version found in data envelope; assuming current version (%d). "
+            "If this data was written by an older version of the code, the load may fail.",
+            meta.name,
+            meta.version,
+        )
+        fieldsData = _stripEnvelope(data)
+    elif fileVersion < meta.version:
+        fieldsData = _stripEnvelope(data)
+        fieldsData = applyMigrationRange(
+            actualCls, fieldsData, fileVersion, meta.version, upgradeInPlace=upgradeInPlace
+        )
+    elif fileVersion > meta.version:
+        raise VersionError(
+            f"Nested {meta.name}: file version ({fileVersion}) is newer than class version "
+            f"({meta.version}). Cannot downgrade."
+        )
+    else:
+        fieldsData = _stripEnvelope(data)
+
+    # Unknown-field handling per the resolved class's policy.
+    fields = _resolveFields(actualCls)
+    knownFieldNames = set(fields.keys())
+    unknownFields = set(fieldsData.keys()) - knownFieldNames
+    if unknownFields:
+        if meta.unknown == "error":
+            raise UnknownFieldError(f"Unknown fields in nested {meta.name}: {sorted(unknownFields)}")
+        if meta.unknown == "ignore":
+            for name in unknownFields:
+                del fieldsData[name]
+        # "preserve" mode: leave them; field iteration won't include them in kwargs.
+
+    dcFields = {f.name: f for f in dataclasses.fields(actualCls)}  # type: ignore[arg-type]
     kwargs: dict[str, Any] = {}
     for fieldName, fieldType in fields.items():
-        if fieldName in data:
-            rawValue = data[fieldName]
+        if fieldName in fieldsData:
+            rawValue = fieldsData[fieldName]
             if fieldName in lazyFields or getattr(rawValue, "_isLazySentinel", False):
                 # Lazy sentinel — pass through without deserialization
                 kwargs[fieldName] = rawValue
             else:
                 dcField = dcFields.get(fieldName)
                 dcMeta = dcField.metadata if dcField is not None else None
+                # Use this class's own validate_literals setting for its own fields;
+                # nested Versionable boundaries re-read their own meta inside their
+                # own _deserializeVersionable call. upgradeInPlace propagates so
+                # nested requiresUpgrade() migrations honor the root load() flag.
                 kwargs[fieldName] = deserialize(
-                    rawValue, fieldType, fieldMetadata=dcMeta, validateLiterals=meta.validateLiterals
+                    rawValue,
+                    fieldType,
+                    fieldMetadata=dcMeta,
+                    validateLiterals=meta.validateLiterals,
+                    upgradeInPlace=upgradeInPlace,
                 )
         elif fieldName in dcFields:
             dcField = dcFields[fieldName]
@@ -591,7 +855,7 @@ def _deserializeVersionable(data: dict[str, Any], cls: type[Versionable]) -> Ver
             elif dcField.default_factory is not dataclasses.MISSING:
                 kwargs[fieldName] = dcField.default_factory()
 
-    instance = cls(**kwargs)
+    instance = actualCls(**kwargs)
     if lazyFields:
         from versionable._lazy import makeLazyInstance
 

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -158,24 +158,6 @@ class TestJsonLiteral:
         with pytest.raises(ConverterError, match="banana"):
             versionable.load(WithLiteral, p)
 
-    def test_validateLiteralsOptOutViaLoad(self, tmp_path: Path) -> None:
-        p = tmp_path / "out.json"
-        p.write_text(
-            json.dumps(
-                {
-                    "__versionable__": {
-                        "object": "WithLiteral",
-                        "version": 1,
-                        "hash": "",
-                    },
-                    "name": "test",
-                    "mode": "banana",
-                }
-            )
-        )
-        loaded = versionable.load(WithLiteral, p, validateLiterals=False)
-        assert loaded.mode == "banana"
-
 
 class TestJsonMissingVersion:
     def test_noVersionDefaultsToCurrentVersion(self, tmp_path: Path) -> None:

--- a/tests/test_nested_migrations.py
+++ b/tests/test_nested_migrations.py
@@ -1,0 +1,1030 @@
+"""Tests for nested migration recursion, polymorphism, and related behaviors.
+
+Each test isolates its registry mutations via the autouse fixture below — the
+nested-migration test pattern routinely redefines the same class name at v1
+then v2 within a single test, which would collide with the global `_REGISTRY`
+otherwise.
+
+Hashes are omitted (default ``""``) on test classes, matching the existing
+`test_migration.py` convention; the hash check is skipped when hash is empty.
+
+Note: this file intentionally does not use ``from __future__ import
+annotations``. Tests define Versionable classes inside functions and reference
+each other by name in type annotations (e.g., ``items: list[_BV2]``).
+With deferred annotations active, ``typing.get_type_hints`` would try to
+resolve these class names against the module's globals (where they don't exist
+— they're function-local) and fall back to raw string annotations, which
+``_deserializeConcrete`` can't dispatch through. Evaluating annotations
+eagerly captures the class objects at definition time, when they're in scope.
+"""
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+import versionable
+from versionable import Migration, MigrationContext, Versionable, migration
+from versionable._base import _REGISTRY
+from versionable.errors import (
+    BackendError,
+    ConverterError,
+    UnknownFieldError,
+    UpgradeRequiredError,
+    VersionError,
+)
+
+
+def _has_toml() -> bool:
+    try:
+        import toml  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_yaml() -> bool:
+    try:
+        import yaml  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_h5py() -> bool:
+    try:
+        import h5py  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Snapshot _REGISTRY before each test, restore after.
+
+    Allows tests to redefine the same class name at different versions (e.g., B
+    at v1 to write a file, then B at v2 to load it) without polluting other
+    tests' state.
+    """
+    before = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(before)
+
+
+# ---------------------------------------------------------------------------
+# Migration recursion
+# ---------------------------------------------------------------------------
+
+
+class TestSingleNestedMigration:
+    """Test 1: single-field nested migration — A.point: B, save B-v1, load B-v2.
+
+    Covered per backend to confirm each delivers the nested envelope in a shape
+    the recursion can read.
+    """
+
+    def _save_v1_then_define_v2(self, p: Path, backend_save: callable) -> type:
+        """Save a v1 file with B-v1, then redefine B at v2 with a rename migration.
+
+        Returns the v2 container class for loading.
+        """
+
+        @dataclass
+        class _BV1(Versionable, version=1, name="NMig1_B", register=True):
+            title: str
+
+        @dataclass
+        class _AV1(Versionable, version=1, name="NMig1_A", register=True):
+            point: _BV1
+
+        backend_save(_AV1(point=_BV1(title="hello")), p)
+
+        _REGISTRY.pop("NMig1_B", None)
+        _REGISTRY.pop("NMig1_A", None)
+
+        @dataclass
+        class _BV2(Versionable, version=2, name="NMig1_B", register=True):
+            name: str
+
+            class Migrate:
+                v1 = Migration().rename("title", "name")
+
+        @dataclass
+        class _AV1WithV2B(Versionable, version=1, name="NMig1_A", register=True):
+            point: _BV2
+
+        return _AV1WithV2B
+
+    def test_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.json"
+        a_cls = self._save_v1_then_define_v2(p, versionable.save)
+        loaded = versionable.load(a_cls, p)
+        assert loaded.point.name == "hello"
+
+    @pytest.mark.skipif(not _has_yaml(), reason="yaml not installed")
+    def test_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.yaml"
+        a_cls = self._save_v1_then_define_v2(p, versionable.save)
+        loaded = versionable.load(a_cls, p)
+        assert loaded.point.name == "hello"
+
+    @pytest.mark.skipif(not _has_toml(), reason="toml not installed")
+    def test_toml(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.toml"
+        a_cls = self._save_v1_then_define_v2(p, versionable.save)
+        loaded = versionable.load(a_cls, p)
+        assert loaded.point.name == "hello"
+
+    @pytest.mark.skipif(not _has_h5py(), reason="h5py not installed")
+    def test_hdf5(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.h5"
+        a_cls = self._save_v1_then_define_v2(p, versionable.save)
+        loaded = versionable.load(a_cls, p)
+        assert loaded.point.name == "hello"
+
+
+def test_list_element_migration(tmp_path: Path) -> None:
+    """Test 2: each element of list[B] gets migrated."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig2_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig2_A", register=True):
+        items: list[_BV1]
+
+    versionable.save(_AV1(items=[_BV1(title="a"), _BV1(title="b")]), p)
+
+    _REGISTRY.pop("NMig2_B", None)
+    _REGISTRY.pop("NMig2_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig2_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig2_A", register=True):
+        items: list[_BV2]
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert [b.name for b in loaded.items] == ["a", "b"]
+
+
+def test_dict_value_migration(tmp_path: Path) -> None:
+    """Test 3: each value of dict[str, B] gets migrated."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig3_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig3_A", register=True):
+        by_key: dict[str, _BV1]
+
+    versionable.save(_AV1(by_key={"x": _BV1(title="hello")}), p)
+
+    _REGISTRY.pop("NMig3_B", None)
+    _REGISTRY.pop("NMig3_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig3_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig3_A", register=True):
+        by_key: dict[str, _BV2]
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert loaded.by_key["x"].name == "hello"
+
+
+def test_tuple_element_migration(tmp_path: Path) -> None:
+    """Test 4: each element of tuple[B, ...] gets migrated."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig4_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig4_A", register=True):
+        items: tuple[_BV1, ...]
+
+    versionable.save(_AV1(items=(_BV1(title="a"), _BV1(title="b"))), p)
+
+    _REGISTRY.pop("NMig4_B", None)
+    _REGISTRY.pop("NMig4_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig4_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig4_A", register=True):
+        items: tuple[_BV2, ...]
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert isinstance(loaded.items, tuple)
+    assert [b.name for b in loaded.items] == ["a", "b"]
+
+
+def test_set_element_migration(tmp_path: Path) -> None:
+    """Test 5: each element of set[B] gets migrated. B must be hashable."""
+    p = tmp_path / "data.json"
+
+    @dataclass(frozen=True)
+    class _BV1(Versionable, version=1, name="NMig5_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig5_A", register=True):
+        items: set[_BV1]
+
+    versionable.save(_AV1(items={_BV1(title="a"), _BV1(title="b")}), p)
+
+    _REGISTRY.pop("NMig5_B", None)
+    _REGISTRY.pop("NMig5_A", None)
+
+    @dataclass(frozen=True)
+    class _BV2(Versionable, version=2, name="NMig5_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig5_A", register=True):
+        items: set[_BV2]
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert {b.name for b in loaded.items} == {"a", "b"}
+
+
+def test_multistep_chain_at_nested_level(tmp_path: Path) -> None:
+    """Test 6: B v1 → v2 → v3 chain applied to a nested element."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig6_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig6_A", register=True):
+        b: _BV1
+
+    versionable.save(_AV1(b=_BV1(title="hello")), p)
+
+    _REGISTRY.pop("NMig6_B", None)
+    _REGISTRY.pop("NMig6_A", None)
+
+    @dataclass
+    class _BV3(Versionable, version=3, name="NMig6_B", register=True):
+        name: str
+        count: int = 0
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+            v2 = Migration().add("count", default=42)
+
+    @dataclass
+    class _AV1WithV3B(Versionable, version=1, name="NMig6_A", register=True):
+        b: _BV3
+
+    loaded = versionable.load(_AV1WithV3B, p)
+    assert loaded.b.name == "hello"
+    assert loaded.b.count == 42
+
+
+def test_parent_and_child_both_migrated(tmp_path: Path) -> None:
+    """Test 7: A-v1 → A-v2 plus B-v1 → B-v2 applied at appropriate levels."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig7_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig7_A", register=True):
+        label: str
+        b: _BV1
+
+    versionable.save(_AV1(label="parent", b=_BV1(title="child")), p)
+
+    _REGISTRY.pop("NMig7_B", None)
+    _REGISTRY.pop("NMig7_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig7_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV2(Versionable, version=2, name="NMig7_A", register=True):
+        title: str  # renamed from "label"
+        b: _BV2
+
+        class Migrate:
+            v1 = Migration().rename("label", "title")
+
+    loaded = versionable.load(_AV2, p)
+    assert loaded.title == "parent"
+    assert loaded.b.name == "child"
+
+
+def test_newer_nested_version_raises(tmp_path: Path) -> None:
+    """Test 8: nested file version > class version raises VersionError naming the type."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig8_B", register=True):
+        name: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig8_A", register=True):
+        b: _BV2
+
+    versionable.save(_AV1(b=_BV2(name="x")), p)
+
+    _REGISTRY.pop("NMig8_B", None)
+    _REGISTRY.pop("NMig8_A", None)
+
+    @dataclass
+    class _BV1Only(Versionable, version=1, name="NMig8_B", register=True):
+        name: str
+
+    @dataclass
+    class _AV1WithOldB(Versionable, version=1, name="NMig8_A", register=True):
+        b: _BV1Only
+
+    with pytest.raises(VersionError, match="NMig8_B"):
+        versionable.load(_AV1WithOldB, p)
+
+
+def test_missing_nested_envelope_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test 9: nested data without an envelope logs a warning and assumes current version."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _B(Versionable, version=1, name="NMig9_B", register=True):
+        name: str
+
+    @dataclass
+    class _A(Versionable, version=1, name="NMig9_A", register=True):
+        b: _B
+
+    # Hand-craft a file with no nested envelope at all (no __versionable__ wrapper,
+    # no flat envelope keys).
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NMig9_A", "version": 1, "hash": ""},
+                "b": {"name": "x"},
+            }
+        )
+    )
+    with caplog.at_level("WARNING"):
+        loaded = versionable.load(_A, p)
+    assert loaded.b.name == "x"
+    assert any("NMig9_B" in m and "no version" in m for m in caplog.messages)
+
+
+def test_imperative_migration_on_nested_type(tmp_path: Path) -> None:
+    """Test 10: imperative @migration decorator works at nested level."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig10_B", register=True):
+        old_field: int
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig10_A", register=True):
+        b: _BV1
+
+    versionable.save(_AV1(b=_BV1(old_field=5)), p)
+
+    _REGISTRY.pop("NMig10_B", None)
+    _REGISTRY.pop("NMig10_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig10_B", register=True):
+        new_field: int
+
+        class Migrate:
+            @migration(fromVersion=1)
+            def from_v1(ctx: MigrationContext) -> None:  # noqa: N805  # @migration wraps this; not a regular method
+                ctx["new_field"] = ctx.pop("old_field") * 2
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig10_A", register=True):
+        b: _BV2
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert loaded.b.new_field == 10
+
+
+def test_three_level_deep_migration(tmp_path: Path) -> None:
+    """Test 11: A.b: B, B.c: C — all three classes migrate v1 → v2."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _CV1(Versionable, version=1, name="NMig11_C", register=True):
+        c_old: str
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig11_B", register=True):
+        b_old: str
+        c: _CV1
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig11_A", register=True):
+        a_old: str
+        b: _BV1
+
+    versionable.save(_AV1(a_old="A", b=_BV1(b_old="B", c=_CV1(c_old="C"))), p)
+
+    _REGISTRY.pop("NMig11_C", None)
+    _REGISTRY.pop("NMig11_B", None)
+    _REGISTRY.pop("NMig11_A", None)
+
+    @dataclass
+    class _CV2(Versionable, version=2, name="NMig11_C", register=True):
+        c_new: str
+
+        class Migrate:
+            v1 = Migration().rename("c_old", "c_new")
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig11_B", register=True):
+        b_new: str
+        c: _CV2
+
+        class Migrate:
+            v1 = Migration().rename("b_old", "b_new")
+
+    @dataclass
+    class _AV2(Versionable, version=2, name="NMig11_A", register=True):
+        a_new: str
+        b: _BV2
+
+        class Migrate:
+            v1 = Migration().rename("a_old", "a_new")
+
+    loaded = versionable.load(_AV2, p)
+    assert loaded.a_new == "A"
+    assert loaded.b.b_new == "B"
+    assert loaded.b.c.c_new == "C"
+
+
+@pytest.mark.skipif(not _has_yaml() or not _has_toml(), reason="yaml or toml not installed")
+def test_cross_backend_yaml_to_toml(tmp_path: Path) -> None:
+    """Test 12: save in YAML at v1, load in TOML at v2 — migrations apply regardless of backend."""
+    yaml_path = tmp_path / "v1.yaml"
+    toml_path = tmp_path / "v1.toml"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig12_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig12_A", register=True):
+        b: _BV1
+
+    obj = _AV1(b=_BV1(title="hello"))
+    versionable.save(obj, yaml_path)
+
+    # Re-read YAML, re-write as TOML to exercise cross-backend migration.
+    import yaml as yaml_lib
+
+    yaml_data = yaml_lib.safe_load(yaml_path.read_text())
+    import toml as toml_lib
+
+    toml_path.write_text(toml_lib.dumps(yaml_data))
+
+    _REGISTRY.pop("NMig12_B", None)
+    _REGISTRY.pop("NMig12_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig12_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig12_A", register=True):
+        b: _BV2
+
+    loaded = versionable.load(_AV1WithV2B, toml_path)
+    assert loaded.b.name == "hello"
+
+
+@pytest.mark.skipif(not _has_h5py(), reason="h5py not installed")
+def test_hdf5_nested_migration_via_load_lazy(tmp_path: Path) -> None:
+    """Test 13: nested migration through HDF5's loadLazy reader path."""
+    p = tmp_path / "data.h5"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NMig13_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NMig13_A", register=True):
+        items: list[_BV1]
+
+    versionable.save(_AV1(items=[_BV1(title="a"), _BV1(title="b")]), p)
+
+    _REGISTRY.pop("NMig13_B", None)
+    _REGISTRY.pop("NMig13_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NMig13_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NMig13_A", register=True):
+        items: list[_BV2]
+
+    loaded = versionable.load(_AV1WithV2B, p)
+    assert [b.name for b in loaded.items] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Polymorphism
+# ---------------------------------------------------------------------------
+
+
+class TestPolymorphism:
+    """Tests 14, 16, 17: polymorphic resolution, errors, and runtime preservation."""
+
+    def test_subclass_identity_preserved_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.json"
+
+        @dataclass
+        class _Animal(Versionable, version=1, name="NPoly14_Animal", register=True):
+            name: str
+
+        @dataclass
+        class _Dog(_Animal, version=1, name="NPoly14_Dog", register=True):
+            breed: str = "mutt"
+
+        @dataclass
+        class _Cat(_Animal, version=1, name="NPoly14_Cat", register=True):
+            indoor: bool = True
+
+        @dataclass
+        class _Zoo(Versionable, version=1, name="NPoly14_Zoo", register=True):
+            animals: list[_Animal] = field(default_factory=list)
+
+        zoo = _Zoo(animals=[_Dog(name="Rex", breed="lab"), _Cat(name="Whiskers", indoor=False)])
+        versionable.save(zoo, p)
+
+        loaded = versionable.load(_Zoo, p)
+        assert isinstance(loaded.animals[0], _Dog)
+        assert isinstance(loaded.animals[1], _Cat)
+        assert loaded.animals[0].breed == "lab"
+        assert loaded.animals[1].indoor is False
+
+    @pytest.mark.skipif(not _has_h5py(), reason="h5py not installed")
+    def test_subclass_identity_preserved_hdf5(self, tmp_path: Path) -> None:
+        p = tmp_path / "data.h5"
+
+        @dataclass
+        class _Animal(Versionable, version=1, name="NPolyH_Animal", register=True):
+            name: str
+
+        @dataclass
+        class _Dog(_Animal, version=1, name="NPolyH_Dog", register=True):
+            breed: str = "mutt"
+
+        @dataclass
+        class _Cat(_Animal, version=1, name="NPolyH_Cat", register=True):
+            indoor: bool = True
+
+        @dataclass
+        class _Zoo(Versionable, version=1, name="NPolyH_Zoo", register=True):
+            animals: list[_Animal] = field(default_factory=list)
+
+        zoo = _Zoo(animals=[_Dog(name="Rex", breed="poodle"), _Cat(name="Whiskers", indoor=True)])
+        versionable.save(zoo, p)
+
+        loaded = versionable.load(_Zoo, p)
+        assert isinstance(loaded.animals[0], _Dog)
+        assert isinstance(loaded.animals[1], _Cat)
+        assert loaded.animals[0].breed == "poodle"
+        assert loaded.animals[1].indoor is True
+
+    def test_unknown_object_name_raises(self, tmp_path: Path) -> None:
+        """Test 16: file references a class name not in the registry."""
+        p = tmp_path / "data.json"
+
+        @dataclass
+        class _Animal(Versionable, version=1, name="NPoly16_Animal", register=True):
+            name: str
+
+        @dataclass
+        class _Zoo(Versionable, version=1, name="NPoly16_Zoo", register=True):
+            animals: list[_Animal] = field(default_factory=list)
+
+        # Hand-craft a file that names a class not in the registry.
+        p.write_text(
+            json.dumps(
+                {
+                    "__versionable__": {"object": "NPoly16_Zoo", "version": 1, "hash": ""},
+                    "animals": [
+                        {
+                            "__versionable__": {"object": "NotARealClass", "version": 1, "hash": ""},
+                            "name": "Rex",
+                        }
+                    ],
+                }
+            )
+        )
+
+        with pytest.raises(BackendError, match="NotARealClass"):
+            versionable.load(_Zoo, p)
+
+    def test_resolved_class_not_subclass_raises(self, tmp_path: Path) -> None:
+        """Test 17: file's object resolves to a class that's not a subclass of declared type."""
+        p = tmp_path / "data.json"
+
+        @dataclass
+        class _Animal(Versionable, version=1, name="NPoly17_Animal", register=True):
+            name: str
+
+        @dataclass
+        class _Vehicle(Versionable, version=1, name="NPoly17_Vehicle", register=True):
+            wheels: int
+
+        @dataclass
+        class _Zoo(Versionable, version=1, name="NPoly17_Zoo", register=True):
+            animals: list[_Animal] = field(default_factory=list)
+
+        # Hand-craft a file where the nested element's object resolves to Vehicle
+        # (registered) which is NOT a subclass of Animal.
+        p.write_text(
+            json.dumps(
+                {
+                    "__versionable__": {"object": "NPoly17_Zoo", "version": 1, "hash": ""},
+                    "animals": [
+                        {
+                            "__versionable__": {"object": "NPoly17_Vehicle", "version": 1, "hash": ""},
+                            "wheels": 4,
+                        }
+                    ],
+                }
+            )
+        )
+
+        with pytest.raises(BackendError, match="not a subclass"):
+            versionable.load(_Zoo, p)
+
+
+def test_polymorphism_with_migration(tmp_path: Path) -> None:
+    """Test 15: per-subclass migrations applied to each element by its actual class."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _Animal(Versionable, version=1, name="NPoly15_Animal", register=True):
+        name: str
+
+    @dataclass
+    class _DogV1(_Animal, version=1, name="NPoly15_Dog", register=True):
+        bark: str = "woof"
+
+    @dataclass
+    class _CatV1(_Animal, version=1, name="NPoly15_Cat", register=True):
+        meow: str = "meow"
+
+    @dataclass
+    class _ZooV1(Versionable, version=1, name="NPoly15_Zoo", register=True):
+        animals: list[_Animal] = field(default_factory=list)
+
+    zoo = _ZooV1(
+        animals=[
+            _DogV1(name="Rex", bark="WOOF"),
+            _CatV1(name="Whiskers", meow="MEOW"),
+        ]
+    )
+    versionable.save(zoo, p)
+
+    _REGISTRY.pop("NPoly15_Zoo", None)
+    _REGISTRY.pop("NPoly15_Cat", None)
+    _REGISTRY.pop("NPoly15_Dog", None)
+    _REGISTRY.pop("NPoly15_Animal", None)
+
+    @dataclass
+    class _AnimalV1(Versionable, version=1, name="NPoly15_Animal", register=True):
+        name: str
+
+    @dataclass
+    class _DogV2(_AnimalV1, version=2, name="NPoly15_Dog", register=True):
+        sound: str = "woof"  # renamed from "bark"
+
+        class Migrate:
+            v1 = Migration().rename("bark", "sound")
+
+    @dataclass
+    class _CatV2(_AnimalV1, version=2, name="NPoly15_Cat", register=True):
+        sound: str = "meow"  # renamed from "meow"
+
+        class Migrate:
+            v1 = Migration().rename("meow", "sound")
+
+    @dataclass
+    class _ZooV1WithV2(Versionable, version=1, name="NPoly15_Zoo", register=True):
+        animals: list[_AnimalV1] = field(default_factory=list)
+
+    loaded = versionable.load(_ZooV1WithV2, p)
+    assert isinstance(loaded.animals[0], _DogV2)
+    assert isinstance(loaded.animals[1], _CatV2)
+    assert loaded.animals[0].sound == "WOOF"
+    assert loaded.animals[1].sound == "MEOW"
+
+
+def test_polymorphism_old_names_rename(tmp_path: Path) -> None:
+    """Test 18: file says object='OldDog'; current class registers name='Dog', old_names=['OldDog']."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _Animal(Versionable, version=1, name="NPoly18_Animal", register=True):
+        name: str
+
+    @dataclass
+    class _DogRenamed(_Animal, version=1, name="NPoly18_Dog", old_names=["NPoly18_OldDog"], register=True):
+        breed: str = "mutt"
+
+    @dataclass
+    class _Zoo(Versionable, version=1, name="NPoly18_Zoo", register=True):
+        animals: list[_Animal] = field(default_factory=list)
+
+    # Hand-craft a file using the old name.
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NPoly18_Zoo", "version": 1, "hash": ""},
+                "animals": [
+                    {
+                        "__versionable__": {"object": "NPoly18_OldDog", "version": 1, "hash": ""},
+                        "name": "Rex",
+                        "breed": "lab",
+                    }
+                ],
+            }
+        )
+    )
+
+    loaded = versionable.load(_Zoo, p)
+    assert isinstance(loaded.animals[0], _DogRenamed)
+    assert loaded.animals[0].name == "Rex"
+    assert loaded.animals[0].breed == "lab"
+
+
+# ---------------------------------------------------------------------------
+# Save-side guard
+# ---------------------------------------------------------------------------
+
+
+def test_save_dict_with_versionable_keys_raises(tmp_path: Path) -> None:
+    """Test 19: saving dict[Versionable, X] raises ConverterError, identifying the field path."""
+    p = tmp_path / "data.json"
+
+    @dataclass(frozen=True)
+    class _K(Versionable, version=1, name="NSave19_K", register=True):
+        id: int
+
+    @dataclass
+    class _A(Versionable, version=1, name="NSave19_A", register=True):
+        by_obj: dict[_K, str] = field(default_factory=dict)
+
+    obj = _A(by_obj={_K(id=1): "x"})
+    with pytest.raises(ConverterError, match="Dict keys cannot be Versionable"):
+        versionable.save(obj, p)
+
+
+# ---------------------------------------------------------------------------
+# validate_literals at nested level
+# ---------------------------------------------------------------------------
+
+
+def test_nested_validate_literals_default_validates(tmp_path: Path) -> None:
+    """Default behavior: nested class with default validate_literals=True validates its Literals."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _Inner(Versionable, version=1, name="NLit_Inner_default", register=True):
+        mode: Literal["fast", "slow"] = "fast"
+
+    @dataclass
+    class _Outer(Versionable, version=1, name="NLit_Outer_default", register=True):
+        inner: _Inner
+
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NLit_Outer_default", "version": 1, "hash": ""},
+                "inner": {
+                    "__versionable__": {"object": "NLit_Inner_default", "version": 1, "hash": ""},
+                    "mode": "banana",  # Not a valid Literal option
+                },
+            }
+        )
+    )
+
+    with pytest.raises(ConverterError, match="banana"):
+        versionable.load(_Outer, p)
+
+
+def test_nested_class_validate_literals_setting_honored(tmp_path: Path) -> None:
+    """Nested class's own validate_literals=False applies independently of the parent's setting."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _InnerNoVal(
+        Versionable,
+        version=1,
+        name="NLit_Inner_optout",
+        register=True,
+        validate_literals=False,
+    ):
+        mode: Literal["fast", "slow"] = "fast"
+
+    @dataclass
+    class _Outer(Versionable, version=1, name="NLit_Outer_optout", register=True):
+        inner: _InnerNoVal
+
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NLit_Outer_optout", "version": 1, "hash": ""},
+                "inner": {
+                    "__versionable__": {"object": "NLit_Inner_optout", "version": 1, "hash": ""},
+                    "mode": "banana",
+                },
+            }
+        )
+    )
+
+    # Outer is default validate_literals=True; Inner declared validate_literals=False — Inner's
+    # setting governs Inner's fields, so the invalid Literal value passes through.
+    loaded = versionable.load(_Outer, p)
+    assert loaded.inner.mode == "banana"
+
+
+# ---------------------------------------------------------------------------
+# Unknown-field handling at nested
+# ---------------------------------------------------------------------------
+
+
+def test_nested_unknown_error_raises(tmp_path: Path) -> None:
+    """Test 21: nested class with unknown='error' raises UnknownFieldError on extra field."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _Inner(Versionable, version=1, name="NUnk21_Inner", register=True, unknown="error"):
+        name: str
+
+    @dataclass
+    class _Outer(Versionable, version=1, name="NUnk21_Outer", register=True):
+        inner: _Inner
+
+    # Hand-craft a file with an unknown field on the nested Inner.
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NUnk21_Outer", "version": 1, "hash": ""},
+                "inner": {
+                    "__versionable__": {"object": "NUnk21_Inner", "version": 1, "hash": ""},
+                    "name": "x",
+                    "extra": "should not be here",
+                },
+            }
+        )
+    )
+
+    with pytest.raises(UnknownFieldError, match="NUnk21_Inner"):
+        versionable.load(_Outer, p)
+
+
+def test_nested_unknown_ignore_drops_silently(tmp_path: Path) -> None:
+    """Test 22: nested class with unknown='ignore' silently drops extra fields."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _Inner(Versionable, version=1, name="NUnk22_Inner", register=True, unknown="ignore"):
+        name: str
+
+    @dataclass
+    class _Outer(Versionable, version=1, name="NUnk22_Outer", register=True):
+        inner: _Inner
+
+    p.write_text(
+        json.dumps(
+            {
+                "__versionable__": {"object": "NUnk22_Outer", "version": 1, "hash": ""},
+                "inner": {
+                    "__versionable__": {"object": "NUnk22_Inner", "version": 1, "hash": ""},
+                    "name": "x",
+                    "extra": "drop me",
+                },
+            }
+        )
+    )
+
+    loaded = versionable.load(_Outer, p)
+    assert loaded.inner.name == "x"
+    assert not hasattr(loaded.inner, "extra")
+
+
+# ---------------------------------------------------------------------------
+# upgradeInPlace propagation
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_in_place_at_root(tmp_path: Path) -> None:
+    """load(..., upgradeInPlace=True) suppresses UpgradeRequiredError on root migrations."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NUp_root_A", register=True):
+        title: str
+
+    versionable.save(_AV1(title="hello"), p)
+
+    _REGISTRY.pop("NUp_root_A", None)
+
+    @dataclass
+    class _AV2(Versionable, version=2, name="NUp_root_A", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().requiresUpgrade().rename("title", "name")
+
+    # Without flag → UpgradeRequiredError.
+    with pytest.raises(UpgradeRequiredError):
+        versionable.load(_AV2, p)
+
+    # With flag → migration proceeds.
+    loaded = versionable.load(_AV2, p, upgradeInPlace=True)
+    assert loaded.name == "hello"
+
+
+def test_upgrade_in_place_propagates_to_nested(tmp_path: Path) -> None:
+    """load(..., upgradeInPlace=True) reaches nested Versionable migrations."""
+    p = tmp_path / "data.json"
+
+    @dataclass
+    class _BV1(Versionable, version=1, name="NUp_nested_B", register=True):
+        title: str
+
+    @dataclass
+    class _AV1(Versionable, version=1, name="NUp_nested_A", register=True):
+        b: _BV1
+
+    versionable.save(_AV1(b=_BV1(title="hello")), p)
+
+    _REGISTRY.pop("NUp_nested_B", None)
+    _REGISTRY.pop("NUp_nested_A", None)
+
+    @dataclass
+    class _BV2(Versionable, version=2, name="NUp_nested_B", register=True):
+        name: str
+
+        class Migrate:
+            v1 = Migration().requiresUpgrade().rename("title", "name")
+
+    @dataclass
+    class _AV1WithV2B(Versionable, version=1, name="NUp_nested_A", register=True):
+        b: _BV2
+
+    # Without flag → UpgradeRequiredError fires at the nested level.
+    with pytest.raises(UpgradeRequiredError):
+        versionable.load(_AV1WithV2B, p)
+
+    # With flag → nested migration proceeds.
+    loaded = versionable.load(_AV1WithV2B, p, upgradeInPlace=True)
+    assert loaded.b.name == "hello"

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -163,22 +163,6 @@ class TestTomlLiteral:
         with pytest.raises(ConverterError, match="banana"):
             versionable.load(WithLiteral, p)
 
-    def test_validateLiteralsOptOutViaLoad(self, tmp_path: Path) -> None:
-        import toml
-
-        p = tmp_path / "out.toml"
-        p.write_text(
-            toml.dumps(
-                {
-                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
-                    "name": "test",
-                    "mode": "banana",
-                }
-            )
-        )
-        loaded = versionable.load(WithLiteral, p, validateLiterals=False)
-        assert loaded.mode == "banana"
-
 
 class TestTomlMissingVersion:
     def test_noVersionDefaultsToCurrentVersion(self, tmp_path: Path) -> None:

--- a/tests/test_yaml_backend.py
+++ b/tests/test_yaml_backend.py
@@ -215,20 +215,6 @@ class TestYamlLiteral:
         with pytest.raises(ConverterError, match="banana"):
             versionable.load(WithLiteral, p)
 
-    def test_validateLiteralsOptOutViaLoad(self, tmp_path: Path) -> None:
-        p = tmp_path / "out.yaml"
-        p.write_text(
-            yaml.dump(
-                {
-                    "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
-                    "name": "test",
-                    "mode": "banana",
-                }
-            )
-        )
-        loaded = versionable.load(WithLiteral, p, validateLiterals=False)
-        assert loaded.mode == "banana"
-
     def test_validateLiteralsOptOutViaClass(self, tmp_path: Path) -> None:
         p = tmp_path / "out.yaml"
         p.write_text(


### PR DESCRIPTION
**Description:** Two correctness bugs in nested deserialize, fixed in `_deserializeVersionable`: migrations didn't recurse into nested values, and polymorphism (`list[Animal]` with `Dog`/`Cat` elements) was silently dropped. Builds on the per-element envelope layout shipped in #26 — now the per-element `version` and `object` fields are actually consulted at load time. Also fixes nested `unknown="error"`/`"ignore"` handling, makes the class-level `validate_literals` setting actually reach nested values, and adds a save-side guard against `dict[Versionable, X]`.

**Changes:**

- Migrations apply recursively to nested `Versionable` values: direct fields, list/dict/tuple/set elements, any depth.
- Polymorphism preserved on save/load via per-element envelope `object` name + global registry lookup. Unknown names or wrong-subclass mismatches raise `BackendError` identifying the nested type.
- `unknown` policy honored at every nesting level (each nested class's setting governs its own data).
- Class-level `validate_literals` honored at every nesting level — each nested class's declaration governs its own Literal fields independently of any enclosing class.
- `dict[Versionable, X]` raises `ConverterError` at save time (would silently corrupt today via `str(k)` repr).
- Refactor: `_applyMigrations` moved from `_api.py` to `_migration.py` as `applyMigrationRange` to break a circular import.

**Breaking change:** removed the `validateLiterals` kwarg from `versionable.load()`. It only existed as a workaround for the silent-ignore bug above (the class-level setting wasn't reaching nested values). Now that the class-level setting propagates correctly, the load-time override is redundant. Existing escape hatches remain: `validate_literals=False` on the class, or `literalFallback("...")` for individual fields.

**Tests performed:**

- New `tests/test_nested_migrations.py` covers migration recursion (per backend for the single-field case; JSON for collection types and chains; HDF5 for the loadLazy path; YAML→TOML for cross-backend), polymorphism (subclass identity preserved on JSON + HDF5; per-subclass migrations; `old_names` rename; unknown name error; not-a-subclass error), the dict-key save-side guard, nested `validate_literals` (default validates; nested class's own opt-out honored independently), and nested `unknown` handling.
- Removed 3 obsolete `test_validateLiteralsOptOutViaLoad` tests (one per text backend); class-level `test_validateLiteralsOptOutViaClass` coverage retained.
- Full suite: 469 passed.
- `pixi run --environment default cleanup` clean.

**Out of scope:** Load-time hash validation, polymorphism for `register=False` classes, the envelope-dedup optimization (#28), HDF5 native lazy migrations.