### PR TITLE
Migrate TOML backend from toml to tomlkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 - HDF5 backend now auto-registers `hdf5plugin` filters on import, so files written with zstd/blosc compression can be
   read without the consumer having to import `hdf5plugin` themselves. When `hdf5plugin` is missing and a load fails on a
   filter-related error, the raised `BackendError` now suggests `pip install hdf5plugin` (#20).
+- TOML backend: switched the underlying library from `toml` (unmaintained since 2020) to
+  [`tomlkit`](https://github.com/python-poetry/tomlkit). File format is unchanged; output formatting may differ
+  byte-wise (whitespace, quote style). The `commentDefaults=True` code path is reimplemented on top of tomlkit's
+  structural document API, with commented-out default lines now placed alongside their parent table for cleaner
+  uncomment-to-override workflows. Round-trip preservation of user-added comments is not yet supported (planned for a
+  follow-up).
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add backend support as needed (JSON is included by default):
 
 ```bash
 pip install pyyaml                # YAML backend (.yaml, .yml)
-pip install toml                  # TOML backend (.toml)
+pip install tomlkit               # TOML backend (.toml)
 pip install h5py hdf5plugin       # HDF5 backend (.h5, .hdf5)
 ```
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -8,7 +8,7 @@ type converters, and pluggable storage backends.
 ```bash
 pip install versionable            # Core (JSON backend, no heavy deps)
 pip install pyyaml                 # Add YAML backend
-pip install toml                   # Add TOML backend
+pip install tomlkit                # Add TOML backend
 pip install h5py hdf5plugin        # Add HDF5 backend
 ```
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -84,7 +84,7 @@ import versionable
 # Backend auto-selected by extension
 versionable.save(obj, "config.json")
 versionable.save(obj, "config.yaml")   # requires pyyaml
-versionable.save(obj, "config.toml")   # requires toml
+versionable.save(obj, "config.toml")   # requires tomlkit
 versionable.save(obj, "data.h5")       # requires h5py + hdf5plugin
 
 loaded = versionable.load(MyClass, "config.json")

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -208,7 +208,7 @@ versionable.save(config, "config.toml", commentDefaults=True)
 ```toml
 name = "probe-A"
 sampleRate_Hz = 120000
-# channels = [0, 1, 2]
+# channels = []
 
 [__versionable__]
 object = "SensorConfig"

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -208,13 +208,19 @@ versionable.save(config, "config.toml", commentDefaults=True)
 ```toml
 name = "probe-A"
 sampleRate_Hz = 120000
-# channels = []
+channels = [0, 1, 2]
 
 [__versionable__]
 object = "SensorConfig"
 version = 1
 hash = "9d6951"
 ```
+
+`channels` is uncommented because `[0, 1, 2]` differs from the dataclass default (`[]`); a field whose value matches its
+default would render as `# channels = []`.
+
+Note: hand-added comments in a TOML file are wiped on the next `save()` — the file is regenerated from the parsed Python
+dict, which doesn't carry comments. Round-trip preservation of user-added comments is planned for a follow-up release.
 
 ## HDF5
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -202,22 +202,28 @@ Pass `commentDefaults=True` to comment out fields whose values match the class d
 where you want users to see all available options without all of them being "active":
 
 ```python
-versionable.save(config, "config.toml", commentDefaults=True)
+@dataclass
+class SensorPreset(Versionable, version=1, hash="6f2809"):
+    name: str = "sensor"
+    sampleRate_Hz: int = 48000
+    enabledChannels: list[int] = field(default_factory=lambda: [0, 1])
+
+preset = SensorPreset(name="probe-A")  # only override name
+versionable.save(preset, "preset.toml", commentDefaults=True)
 ```
 
 ```toml
 name = "probe-A"
-sampleRate_Hz = 120000
-channels = [0, 1, 2]
+# sampleRate_Hz = 48000
+# enabledChannels = [0, 1]
 
 [__versionable__]
-object = "SensorConfig"
+object = "SensorPreset"
 version = 1
-hash = "9d6951"
+hash = "6f2809"
 ```
 
-`channels` is uncommented because `[0, 1, 2]` differs from the dataclass default (`[]`); a field whose value matches its
-default would render as `# channels = []`.
+Fields at their default render as `#`-prefixed lines; users uncomment any line to override that default.
 
 Note: hand-added comments in a TOML file are wiped on the next `save()` — the file is regenerated from the parsed Python
 dict, which doesn't carry comments. Round-trip preservation of user-added comments is planned for a follow-up release.

--- a/docs/plans/tomlkit-migration.md
+++ b/docs/plans/tomlkit-migration.md
@@ -1,0 +1,839 @@
+[//]: # (vim: set ft=markdown:)
+
+# TOML Backend: Migrate from `toml` to `tomlkit`
+
+- **Created:** 2026-05-03
+- **Last updated:** 2026-05-03
+- **Status:** Planned
+- **Branch:** `feature/tomlkit` (worktree: `versionable.worktrees/feature-tomlkit/`)
+- **Targets release:** 0.2.0
+- **Tracking issue:** <https://github.com/hendrickmelo/versionable/issues/27>
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unmaintained `toml` package with `tomlkit` in the TOML backend, and rebuild the
+`commentDefaults=True` code path on top of tomlkit's structural document API.
+
+**Architecture:** Boundary conversion (option A in the handoff). Read path calls
+`tomlkit.parse(text).unwrap()` to produce a plain `dict[str, Any]` — every downstream caller stays
+unchanged. Write path builds output two ways: the default branch hands the data dict to
+`tomlkit.dumps(data)`; the `commentDefaults=True` branch builds a `tomlkit.document()` and recursively
+emits each field either as a key-value pair or as a `tomlkit.comment(...)` line, using the dataclass's
+own defaults to decide. Section headers and `__versionable__` envelope tables are never commented.
+
+**Tech stack:** Python 3.12+, [`tomlkit` ≥ 0.13](https://github.com/python-poetry/tomlkit), pixi.
+
+---
+
+## Problem
+
+### 1. The `toml` package is unmaintained
+
+`toml` (PyPI) had its last release as 0.10.2 in November 2020. The ecosystem has consolidated around
+`tomli` / `tomllib` (read) and `tomli_w` / `tomlkit` (write). Shipping with a stale dependency is
+both a maintenance smell and a signal to downstream users that the project isn't keeping current.
+
+### 2. `commentDefaults` is implemented as fragile string-walking
+
+`src/versionable/_toml_backend.py::_commentDefaultLines` dumps the class defaults to TOML, splits the
+result into a set of lines, then walks the actual `toml.dumps(data)` output line-by-line and prepends
+`# ` to lines that match the default-line set. This works today but:
+
+- Every new TOML construct (multi-line arrays, dotted keys, inline tables) is a potential edge case
+  the line-walker has to know about.
+- It cannot preserve user-added comments — they are wiped on every `save()` because we re-emit from
+  the parsed Python dict.
+
+### 3. Layout for nested envelopes is dense
+
+After PR #26's wrap commit, nested Versionables emit their envelope under `[parent.__versionable__]`.
+With `toml.dumps`, sub-tables get pushed to the end of the file — so a config file with two nested
+objects ends up with the data sections at the top and the metadata sub-tables clustered awkwardly at
+the bottom. tomlkit preserves insertion order, so explicit document construction can place each
+`[parent.__versionable__]` directly after its `[parent]` section. (Verify in **Task 3**.)
+
+## Design
+
+### Read path (option A — boundary conversion)
+
+```python
+import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+text = path.read_text(encoding="utf-8")
+data: dict[str, Any] = tomlkit.parse(text).unwrap()
+```
+
+`unwrap()` returns plain Python primitives (`dict`, `list`, `str`, `int`, …) so the existing
+back-compat reader code (`metaTable.get("object", metaTable.get("__OBJECT__", ""))` etc.) works
+unchanged.
+
+Comments on the parsed document are *discarded* at the boundary. Round-trip preservation of
+user-added comments is **out of scope** for this PR — see [Out of scope](#out-of-scope).
+
+### Write path — default branch
+
+```python
+import tomlkit
+content = tomlkit.dumps(data)
+```
+
+`tomlkit.dumps` accepts any `Mapping`, so a plain dict works directly. Output formatting will differ
+byte-wise from `toml.dumps` but is structurally equivalent and round-trips through `tomlkit.parse`.
+
+### Write path — `commentDefaults=True` branch
+
+Replace the line-walking pass with structural document construction. For each field whose serialized
+value equals the dataclass default, emit a `tomlkit.comment(...)` line in place of the key-value pair.
+Recurse into nested Versionable tables to apply the same logic at every level.
+
+```python
+def _emitWithCommentedDefaults(data: dict[str, Any], cls: type) -> str:
+    doc = tomlkit.document()
+    _addContainerWithDefaults(doc, data, cls)
+    return tomlkit.dumps(doc)
+```
+
+`_addContainerWithDefaults` is recursive and handles:
+
+- Scalar fields at default → `tomlkit.comment("name = \"my-server\"")`
+- Scalar fields not at default → `container[key] = value`
+- `__versionable__` sub-tables → always emitted uncommented
+- Nested Versionable dicts → recurse with the field's resolved Versionable class
+
+### Touchpoints
+
+| File                                        | Change                                                                       |
+| ------------------------------------------- | ---------------------------------------------------------------------------- |
+| `pixi.toml`                                 | `[feature.toml.dependencies]`: `toml` → `tomlkit`                            |
+| `pyproject.toml`                            | `[project.optional-dependencies]`: `toml` extra and `all` extra; mypy override |
+| `pixi.lock`                                 | Regenerated by `pixi install`                                                |
+| `src/versionable/_toml_backend.py`          | Library swap + structural rewrite of `_commentDefaultLines`                  |
+| `tests/test_toml_backend.py`                | `pytest.importorskip("toml")` → `tomlkit`; 4 sites of `import toml` replaced |
+| `tests/test_cross_backend_roundtrip.py`     | `import toml as _toml` → `import tomlkit as _tomlkit`                        |
+| `tests/test_cycles.py`                      | Same                                                                         |
+| `tests/test_migration.py`                   | Same                                                                         |
+| `examples/comment_defaults.py`              | Update commented-out expected-output if formatting differs                   |
+| `docs/backends.md`                          | Regenerate the TOML example block if formatting differs                      |
+| `CHANGELOG.md`                              | 0.2.0 entry: dependency swap + any user-visible formatting changes           |
+
+## Test strategy
+
+The existing `tests/test_toml_backend.py` is the spec for user-visible behavior. The plan keeps every
+existing test passing (with assertion adjustments where a test pins exact whitespace that tomlkit
+emits differently). Specific suites:
+
+- **`TestTomlMetadata`** — semantic assertions on parsed structure. Should pass unchanged once the
+  library is swapped.
+- **`TestTomlCommentDefaults`** — pins enough output structure that some assertions may need to relax
+  whitespace. The *intent* of every test is preserved by the structural rewrite.
+- **`TestTomlLiteral`, `TestTomlMissingVersion`, `TestTomlErrors`** — semantic. Should pass unchanged.
+- **`TestTomlBackCompat`** — legacy 0.1.x reads. The backward-compat code operates on Python dicts
+  after parsing, so it's library-agnostic. Verify it still passes.
+
+New tests added in **Task 3**:
+
+- **`test_commentDefaultsEmitsValidToml`** — assert that `commentDefaults=True` output round-trips
+  through `tomlkit.parse` without raising and produces a parseable document.
+- **`test_dependencyImport`** — bare `import tomlkit` succeeds. Trivial guardrail against future
+  accidental dependency removal.
+
+Out-of-scope (documented as a limitation, not tested as a requirement):
+
+- **`test_userCommentsSurviveRoundTrip`** — would require option B (passing `TOMLDocument` through
+  the pipeline). Skipped this PR; tracked as a future enhancement.
+
+## Backwards compatibility
+
+- **File format unchanged.** The on-disk shape (`__versionable__` envelope, nested
+  `[parent.__versionable__]` sub-tables, `__ver_json__` wrappers for ndarray blobs) is identical.
+  Files written by 0.1.x or by the in-flight 0.2.x envelope-keys PR continue to load.
+- **Output formatting differs byte-wise.** `tomlkit.dumps` makes different whitespace and
+  quote-style choices than `toml.dumps`. Files saved with the new code load identically; old files
+  load identically. Diffs on regenerated example files are expected and called out in CHANGELOG.
+- **No API change.** The public `versionable.save() / versionable.load()` signatures are unchanged.
+  `commentDefaults=True` keyword is unchanged.
+
+## Risks
+
+| Risk                                                                                  | Mitigation                                                                              |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `tomlkit.dumps` emits `__ver_json__` ndarray wrappers as section headers, not key-val   | Verified by `TestTomlBackCompat::test_loadOldFormatNdarray` round-trip.                 |
+| Nested-envelope layout (`[parent.__versionable__]`) ordering differs from `toml.dumps`  | This is the *desired* improvement; verify by running examples and visual inspection.    |
+| `tomlkit.dumps` does not reorder scalar fields before `[table]` headers like `toml` did | Existing tests use substring assertions (insensitive to order). If layout is awkward, reorder the `data` dict construction in `save()` to put scalars first, then `__versionable__`, then nested tables. |
+| `TOMLKitError` doesn't catch every parse failure mode `toml.TomlDecodeError` did        | `tests/test_toml_backend.py::TestTomlErrors` exercises malformed-file paths.            |
+| Structural `commentDefaults` rewrite breaks an edge case the line-walker handled        | All `TestTomlCommentDefaults` assertions kept; new round-trip parseability test added.  |
+| `tomlkit.comment("foo")` emits `#foo` (no space) instead of `# foo`                     | Existing tests assert `'# debug = false' in text` (with space). If tomlkit omits the space, pass `tomlkit.comment(" " + line)` to force it. |
+
+## Acceptance
+
+- `pixi run --environment default cleanup && pixi run --environment default pytest` green.
+- `toml` no longer in `pixi.toml`, `pyproject.toml`, or `pixi.lock`; `tomlkit` is.
+- All existing TOML tests pass (with assertion updates for whitespace where appropriate).
+- New `test_commentDefaultsEmitsValidToml` and `test_dependencyImport` added and passing.
+- `examples/comment_defaults.py` runs and its in-file expected output is regenerated if differs.
+- `docs/backends.md` TOML example regenerated if differs.
+- `CHANGELOG.md` 0.2.0 entry mentions the dependency swap.
+
+## Out of scope
+
+- **Round-trip user comment preservation** (read a file with comments, save preserving them).
+  Requires passing `TOMLDocument` through the internal pipeline (option B in the handoff). Type
+  contract on `Backend.load()` would change. Documented as a limitation; future PR.
+- **TOML format-version bump** (introducing `format` in `__versionable__`). Separate concern.
+- **Migration of project's own `pixi.toml` / `pyproject.toml` parsing**. Out of scope — only the
+  library's runtime use of `toml` is in scope.
+
+---
+
+## Tasks
+
+Each task is one commit. Steps inside a task are checkbox-trackable for the executor.
+
+### Task 1: Land this plan doc
+
+**Files:**
+
+- Create: `docs/plans/tomlkit-migration.md` (this file)
+
+- [ ] **Step 1: Verify the file is present and well-formed**
+
+```bash
+ls docs/plans/tomlkit-migration.md
+```
+
+Expected: file listed.
+
+- [ ] **Step 2: Stage and review**
+
+```bash
+git add docs/plans/tomlkit-migration.md
+git diff --cached --stat
+```
+
+Expected: 1 file changed, ~280 insertions.
+
+- [ ] **Step 3: Commit (after user approval per CLAUDE.md)**
+
+```bash
+git commit -m "Add tomlkit migration plan"
+```
+
+---
+
+### Task 2: Swap dependency + library imports + tests in lockstep
+
+This task is one atomic change because pulling the rug on `toml` (removing the dep) breaks every
+test file that imports it directly. Code, deps, tests all move together.
+
+**Files:**
+
+- Modify: `pixi.toml` (lines 30–31)
+- Modify: `pyproject.toml` (line 28, line 31, line 86)
+- Modify: `pixi.lock` (regenerated)
+- Modify: `src/versionable/_toml_backend.py` (lines 41–44, 93, 103–104, 222–224)
+- Modify: `tests/test_toml_backend.py` (lines 8, 44–50, 57–63, 151–161, 167–177)
+- Modify: `tests/test_cross_backend_roundtrip.py` (line 117)
+- Modify: `tests/test_cycles.py` (line 29)
+- Modify: `tests/test_migration.py` (line 23)
+
+- [ ] **Step 1: Update `pixi.toml`**
+
+Replace lines 30–31:
+
+```toml
+[feature.toml.dependencies]
+toml = ">=0.10"
+```
+
+with:
+
+```toml
+[feature.toml.dependencies]
+tomlkit = ">=0.13"
+```
+
+- [ ] **Step 2: Update `pyproject.toml`**
+
+Line 28 — replace:
+
+```toml
+toml = ["toml>=0.10"]
+```
+
+with:
+
+```toml
+toml = ["tomlkit>=0.13"]
+```
+
+Line 31 — replace:
+
+```toml
+all = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0", "toml>=0.10", "pyyaml>=6.0"]
+```
+
+with:
+
+```toml
+all = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0", "tomlkit>=0.13", "pyyaml>=6.0"]
+```
+
+Line 86 — replace:
+
+```toml
+module = ["numpy.*", "h5py.*", "hdf5plugin.*", "toml.*", "yaml.*"]
+```
+
+with:
+
+```toml
+module = ["numpy.*", "h5py.*", "hdf5plugin.*", "tomlkit.*", "yaml.*"]
+```
+
+- [ ] **Step 3: Regenerate `pixi.lock`**
+
+```bash
+pixi install
+```
+
+Expected: lockfile updated to drop `toml`, add `tomlkit`. Repo memory note from
+`feedback_pixi_lock.md` — `pixi install --locked` would fail until the lock is regenerated; use the
+plain `pixi install` here.
+
+- [ ] **Step 4: Verify both deps resolved correctly**
+
+```bash
+pixi list -e default | grep -E "^(toml|tomlkit)\b"
+```
+
+Expected: `tomlkit` listed; `toml` *not* listed.
+
+- [ ] **Step 5: Rewrite the `_toml_backend.py` import + load path**
+
+Replace lines 41–44:
+
+```python
+try:
+    import toml
+except ImportError as e:
+    raise ImportError("TOML backend requires toml — install it with: `pip install toml`") from e
+```
+
+with:
+
+```python
+try:
+    import tomlkit
+    from tomlkit.exceptions import TOMLKitError
+except ImportError as e:
+    raise ImportError("TOML backend requires tomlkit — install it with: `pip install tomlkit`") from e
+```
+
+Replace line 93:
+
+```python
+content = toml.dumps(data)
+```
+
+with:
+
+```python
+content = tomlkit.dumps(data)
+```
+
+Replace lines 103–104:
+
+```python
+data = toml.loads(text)
+except (OSError, toml.TomlDecodeError) as e:
+```
+
+with:
+
+```python
+data = tomlkit.parse(text).unwrap()
+except (OSError, TOMLKitError) as e:
+```
+
+Add the `dict[str, Any]` annotation if pyright requires it:
+
+```python
+data: dict[str, Any] = tomlkit.parse(text).unwrap()
+```
+
+- [ ] **Step 6: Patch `_commentDefaultLines` to use tomlkit (minimal change — full structural rewrite is Task 3)**
+
+Replace lines 222–224:
+
+```python
+buf = io.StringIO()
+toml.dump(defaultSerialized, buf)
+defaultLineSet = set(buf.getvalue().splitlines())
+```
+
+with:
+
+```python
+defaultLineSet = set(tomlkit.dumps(defaultSerialized).splitlines())
+```
+
+Remove the now-unused `import io` at the top of the file (line 36).
+
+- [ ] **Step 7: Update test imports in `tests/test_toml_backend.py`**
+
+Line 8 — replace `pytest.importorskip("toml")` with `pytest.importorskip("tomlkit")`.
+
+Lines 44, 57 — `import toml` → `import tomlkit`.
+Lines 50, 63 — `toml.loads(p.read_text())` → `tomlkit.parse(p.read_text()).unwrap()`.
+
+Lines 151–161 — replace:
+
+```python
+import toml
+
+p = tmp_path / "out.toml"
+p.write_text(
+    toml.dumps(
+        {
+            "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
+            "name": "test",
+            "mode": "banana",
+        }
+    )
+)
+```
+
+with:
+
+```python
+import tomlkit
+
+p = tmp_path / "out.toml"
+p.write_text(
+    tomlkit.dumps(
+        {
+            "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
+            "name": "test",
+            "mode": "banana",
+        }
+    )
+)
+```
+
+Apply the identical replacement at lines 167–177.
+
+- [ ] **Step 8: Update import-skip patterns in cross-backend test files**
+
+In `tests/test_cross_backend_roundtrip.py` line 117, `tests/test_cycles.py` line 29, and
+`tests/test_migration.py` line 23, replace:
+
+```python
+import toml as _toml  # noqa: F401
+```
+
+(or the equivalent) with:
+
+```python
+import tomlkit as _tomlkit  # noqa: F401
+```
+
+Also rename the variable elsewhere in the file if used (`grep -n "_toml" <file>`).
+
+- [ ] **Step 9: Run the test suite and verify everything passes**
+
+```bash
+pixi run --environment default pytest tests/test_toml_backend.py -v
+```
+
+Expected: all tests pass. If `TestTomlCommentDefaults` fails because of whitespace differences in
+the line-walking match, loosen the assertion to a `.splitlines()` comparison or update the expected
+substring. Note any failures with their fix in this step's commit.
+
+```bash
+pixi run --environment default pytest -v
+```
+
+Expected: all tests across the suite pass.
+
+- [ ] **Step 10: Run cleanup**
+
+```bash
+pixi run --environment default cleanup
+```
+
+Expected: clean. Fix any reported errors before committing.
+
+- [ ] **Step 11: Show staged diff for review, then commit (after user approval)**
+
+```bash
+git add pixi.toml pyproject.toml pixi.lock src/versionable/_toml_backend.py \
+        tests/test_toml_backend.py tests/test_cross_backend_roundtrip.py \
+        tests/test_cycles.py tests/test_migration.py
+git diff --cached --stat
+```
+
+Commit:
+
+```bash
+git commit -m "Swap toml dependency for tomlkit in TOML backend"
+```
+
+---
+
+### Task 3: Rewrite `commentDefaults` as structural document construction
+
+The line-walking trick from `_commentDefaultLines` is library-agnostic but doesn't gain any of
+tomlkit's advantages. This task replaces it with explicit `tomlkit.comment(...)` insertion in a
+constructed document.
+
+**Files:**
+
+- Modify: `src/versionable/_toml_backend.py` (rewrite `_commentDefaultLines` and its caller)
+- Modify: `tests/test_toml_backend.py` (add new tests)
+
+- [ ] **Step 1: Write the failing test for parseability**
+
+Append to `tests/test_toml_backend.py`, inside `TestTomlCommentDefaults`:
+
+```python
+def test_commentDefaultsEmitsValidToml(self, tmp_path: Path) -> None:
+    """commentDefaults output is parseable as valid TOML and round-trips."""
+    import tomlkit
+
+    obj = SimpleConfig(name="test")
+    p = tmp_path / "out.toml"
+    versionable.save(obj, p, commentDefaults=True)
+
+    # Parsing should not raise — the file with commented defaults is valid TOML
+    parsed = tomlkit.parse(p.read_text()).unwrap()
+    assert parsed["__versionable__"]["object"] == "SimpleConfig"
+    assert parsed["name"] == "test"
+    # Commented defaults are not present as keys
+    assert "debug" not in parsed
+    assert "retries" not in parsed
+```
+
+- [ ] **Step 2: Write the failing test for the trivial dependency import guardrail**
+
+Append to `tests/test_toml_backend.py` as a top-level test (outside any class):
+
+```python
+def test_dependencyImport() -> None:
+    """tomlkit imports cleanly — guardrail against accidental dep removal."""
+    import tomlkit
+
+    assert hasattr(tomlkit, "parse")
+    assert hasattr(tomlkit, "dumps")
+```
+
+- [ ] **Step 3: Run both new tests**
+
+```bash
+pixi run --environment default pytest \
+    tests/test_toml_backend.py::TestTomlCommentDefaults::test_commentDefaultsEmitsValidToml \
+    tests/test_toml_backend.py::test_dependencyImport -v
+```
+
+Expected: `test_commentDefaultsEmitsValidToml` PASSES already (the line-walker output is also valid
+TOML). `test_dependencyImport` PASSES. The new tests pin behavior; the structural rewrite below
+must keep them passing.
+
+- [ ] **Step 4: Replace `_commentDefaultLines` with structural construction**
+
+In `src/versionable/_toml_backend.py`, delete the entire `_commentDefaultLines` function (lines
+178–256 in the original) and replace with:
+
+```python
+def _emitWithCommentedDefaults(data: dict[str, Any], cls: type) -> str:
+    """Build TOML output where fields at their default value appear as comment lines.
+
+    Walks `data` in parallel with the dataclass's defaults. For each scalar/list field
+    whose serialized value matches the default, emit a ``# key = value`` comment instead
+    of a key-value pair. Section headers and ``__versionable__`` envelope tables are
+    never commented. Nested Versionable tables recurse with their own defaults.
+    """
+    doc = tomlkit.document()
+    _addContainerWithDefaults(doc, data, cls)
+    return tomlkit.dumps(doc)
+
+
+def _addContainerWithDefaults(
+    container: Any,  # tomlkit.TOMLDocument | tomlkit.items.Table
+    data: dict[str, Any],
+    cls: type | None,
+) -> None:
+    """Populate `container` with `data`; commented defaults driven by `cls`."""
+    defaults = _classDefaultsToml(cls) if cls is not None else {}
+    fieldTypes = _resolveFields(cls) if cls is not None else {}
+
+    for key, value in data.items():
+        if key == "__versionable__":
+            sub = tomlkit.table()
+            for metaKey, metaVal in value.items():
+                sub[metaKey] = metaVal
+            container[key] = sub
+            continue
+
+        if isinstance(value, dict):
+            sub = tomlkit.table()
+            nestedCls = _findVersionableType(fieldTypes.get(key))
+            _addContainerWithDefaults(sub, value, nestedCls)
+            container[key] = sub
+            continue
+
+        if key in defaults and value == defaults[key]:
+            scratch = tomlkit.document()
+            scratch[key] = value
+            line = tomlkit.dumps(scratch).rstrip("\n")
+            container.add(tomlkit.comment(line))
+        else:
+            container[key] = value
+
+
+def _classDefaultsToml(cls: type) -> dict[str, Any]:
+    """Compute serialized + TOML-safe defaults for each field of `cls`."""
+    import dataclasses
+
+    from versionable._types import serialize
+
+    dcFields = {f.name: f for f in dataclasses.fields(cls)}
+    resolvedFields = _resolveFields(cls)
+    out: dict[str, Any] = {}
+    for name, tp in resolvedFields.items():
+        dcField = dcFields.get(name)
+        if dcField is None:
+            continue
+        if dcField.default is not dataclasses.MISSING:
+            val = serialize(dcField.default, tp)
+            if val is not None:
+                out[name] = _toTomlSafe(val)
+        elif dcField.default_factory is not dataclasses.MISSING:
+            val = serialize(dcField.default_factory(), tp)
+            if val is not None:
+                out[name] = _toTomlSafe(val)
+    return out
+
+
+def _findVersionableType(fieldType: Any) -> type | None:
+    """If `fieldType` is a Versionable subclass, return it; else None.
+
+    Parameterized types like ``list[Inner]`` are not unwrapped — commentDefaults
+    does not recurse into list elements (matches existing behavior).
+    """
+    from versionable._base import Versionable
+
+    if isinstance(fieldType, type) and issubclass(fieldType, Versionable):
+        return fieldType
+    return None
+```
+
+Update the imports at the top of `_toml_backend.py`:
+
+```python
+from versionable._base import _resolveFields
+```
+
+(already imported — confirm). Remove the now-unused inline imports inside the deleted function.
+
+- [ ] **Step 5: Update the call site in `save()`**
+
+Replace lines 92–96:
+
+```python
+try:
+    content = toml.dumps(data)
+    if commentDefaults:
+        content = _commentDefaultLines(content, fields, meta["name"])
+    path.write_text(content, encoding="utf-8")
+```
+
+with:
+
+```python
+try:
+    if commentDefaults:
+        content = _emitWithCommentedDefaults(data, cls)
+    else:
+        content = tomlkit.dumps(data)
+    path.write_text(content, encoding="utf-8")
+```
+
+Note: the existing `objectName` lookup (`meta["name"]`) is no longer needed because `cls` is already
+in scope (passed by `_api.save`). The structural rewrite uses `cls` directly.
+
+- [ ] **Step 6: Run the full TOML test suite**
+
+```bash
+pixi run --environment default pytest tests/test_toml_backend.py -v
+```
+
+Expected: all tests pass, including:
+
+- `TestTomlCommentDefaults::test_defaultsCommentedOut`
+- `TestTomlCommentDefaults::test_nonDefaultsNotCommented`
+- `TestTomlCommentDefaults::test_commentedFileLoadsWithDefaults`
+- `TestTomlCommentDefaults::test_nestedSectionHeadersNotCommented`
+- `TestTomlCommentDefaults::test_commentDefaultsEmitsValidToml` (new)
+- `test_dependencyImport` (new)
+
+If any test fails: investigate the structural output. Likely failure modes:
+
+- **Whitespace around section headers.** Adjust the assertion to be whitespace-tolerant (e.g.,
+  `'object = "Inner"' in text` is robust; `'\n[__versionable__]\n' in text` is brittle — prefer the
+  former).
+- **Missing space after `#` in commented lines.** `tomlkit.comment("foo")` may emit `#foo` instead
+  of `# foo`. The fix is to construct the comment with a leading space:
+  `tomlkit.comment(" " + line)` inside `_addContainerWithDefaults`. Verify with a quick repl check
+  before adjusting.
+- **Section ordering.** If `[__versionable__]` ends up before scalar fields and that breaks any
+  substring assertion that *also* checks line position, prefer reordering the `data` dict in
+  `save()` to put scalar fields first, then `[__versionable__]`, then nested tables.
+
+- [ ] **Step 7: Run the full test suite to catch cross-test regressions**
+
+```bash
+pixi run --environment default pytest -v
+```
+
+Expected: green.
+
+- [ ] **Step 8: Run cleanup**
+
+```bash
+pixi run --environment default cleanup
+```
+
+Expected: clean.
+
+- [ ] **Step 9: Show diff and commit (after user approval)**
+
+```bash
+git add src/versionable/_toml_backend.py tests/test_toml_backend.py
+git diff --cached --stat
+git commit -m "Rewrite commentDefaults with structural tomlkit document construction"
+```
+
+---
+
+### Task 4: Refresh docs, examples, CHANGELOG
+
+The library output formatting may differ from `toml.dumps`. Verify and regenerate the affected
+documentation and example output blocks.
+
+**Files:**
+
+- Modify: `examples/comment_defaults.py` (in-file expected output, lines 57–113)
+- Modify: `docs/backends.md` (TOML example block, lines 130–146 and 178–217)
+- Modify: `CHANGELOG.md` (0.2.0 entry)
+
+- [ ] **Step 1: Run the example and capture current output**
+
+```bash
+pixi run --environment default python examples/comment_defaults.py
+```
+
+Expected: the example runs cleanly and prints `=== TOML ===` and `=== YAML ===` blocks.
+
+Visually compare the printed TOML block against the commented expected output in
+`examples/comment_defaults.py` lines 57–87 (the `# Output TOML file:` block). The YAML block is not
+affected by this PR, so its expected output should match unchanged.
+
+- [ ] **Step 2: Update the in-file expected output if it differs**
+
+Open `examples/comment_defaults.py`. The expected output is in commented lines 57–113. If the actual
+output from Step 1 differs, replace the commented block to match the new output verbatim, preserving
+the leading `# ` on each line.
+
+If the output matches: skip this step.
+
+- [ ] **Step 3: Verify `docs/backends.md` TOML examples match real output**
+
+Construct a minimal `SensorConfig` matching the docs (lines 132–141 — `name = "probe-A"`,
+`sampleRate_Hz = 120000`, `channels = [0, 1, 2]`) and save it:
+
+```bash
+pixi run --environment default python -c '
+from dataclasses import dataclass, field
+import versionable
+from versionable import Versionable
+
+@dataclass
+class SensorConfig(Versionable, version=1, hash="9d6951"):
+    name: str
+    sampleRate_Hz: int
+    channels: list[int] = field(default_factory=list)
+
+cfg = SensorConfig(name="probe-A", sampleRate_Hz=120000, channels=[0, 1, 2])
+versionable.save(cfg, "/tmp/sensor.toml")
+print(open("/tmp/sensor.toml").read())
+'
+```
+
+Compare with the docs block at `docs/backends.md` lines 132–141. If the order of sections, the
+quoting style, or the whitespace differs, update the docs block to match.
+
+Apply the same check for the `commentDefaults=True` example block (lines 209–217) and the
+nested-Versionable example block (lines 178–195).
+
+- [ ] **Step 4: Append a CHANGELOG entry**
+
+In `CHANGELOG.md`, under `## 0.2.0 (unreleased)`, append (a new bullet at the end of the existing
+list):
+
+```markdown
+- TOML backend: switched the underlying library from `toml` (unmaintained since 2020) to
+  [`tomlkit`](https://github.com/python-poetry/tomlkit). File format is unchanged; output formatting
+  may differ byte-wise (whitespace, quote style). The `commentDefaults=True` code path is reimplemented
+  on top of tomlkit's structural document API. Round-trip preservation of user-added comments is not
+  yet supported (planned for a follow-up).
+```
+
+- [ ] **Step 5: Run tests and cleanup once more to catch any stray references**
+
+```bash
+pixi run --environment default cleanup && pixi run --environment default pytest
+```
+
+Expected: green.
+
+- [ ] **Step 6: Show diff and commit (after user approval)**
+
+```bash
+git add examples/comment_defaults.py docs/backends.md CHANGELOG.md
+git diff --cached --stat
+git commit -m "Refresh docs, example output, and CHANGELOG for tomlkit migration"
+```
+
+---
+
+## Suggested PR description (after all tasks land)
+
+**Description:** Migrate the TOML backend from the unmaintained `toml` package to `tomlkit`, and
+rebuild the `commentDefaults=True` code path on top of tomlkit's structural document API.
+
+**Changes:**
+
+- Swap `toml` for `tomlkit` in `pixi.toml`, `pyproject.toml`, `pixi.lock`, and the `[tool.mypy]`
+  module override.
+- Rewrite `_toml_backend.py` to call `tomlkit.parse(text).unwrap()` on read and `tomlkit.dumps(data)`
+  on write.
+- Replace the `_commentDefaultLines` line-walker with `_emitWithCommentedDefaults`, which constructs
+  a `tomlkit.document()` and emits default-valued fields as `tomlkit.comment(...)` lines.
+- Update tests that imported `toml` directly; switch `pytest.importorskip` targets.
+- Refresh `examples/comment_defaults.py` and `docs/backends.md` example output blocks.
+
+**Tests performed:**
+
+- `pixi run --environment default pytest` — full suite green.
+- `examples/comment_defaults.py` runs and produces the documented output.
+
+## Open questions resolved during planning
+
+1. **Round-trip user comment preservation.** Out of scope for this PR. Documented as a future
+   enhancement in `Out of scope` and the CHANGELOG entry.
+2. **Existing 0.1.x-saved files with `commentDefaults=True`.** Output formatting will differ
+   byte-wise from new saves; loading still works. Mentioned in CHANGELOG.
+3. **Nested-envelope layout improvement.** Likely fixed for free by tomlkit's insertion-order
+   serialization, but explicitly verified in **Task 4 Step 3** by visual comparison with the docs.

--- a/examples/comment_defaults.py
+++ b/examples/comment_defaults.py
@@ -70,15 +70,15 @@ if __name__ == "__main__":
 # # maxConnections = 10
 # # timeoutSec = 30.0
 #
-# [logging]
-# # level = "INFO"
-# # filePath = "/var/log/app.log"
-# # rotateAfterMB = 100
-#
 # [database.__versionable__]
 # object = "DatabaseConfig"
 # version = 1
 # hash = ""
+#
+# [logging]
+# # level = "INFO"
+# # filePath = "/var/log/app.log"
+# # rotateAfterMB = 100
 #
 # [logging.__versionable__]
 # object = "LoggingConfig"

--- a/pixi.lock
+++ b/pixi.lock
@@ -89,8 +89,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -253,8 +253,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.15.9-h16586dd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -419,8 +419,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.15.9-hc5c3a1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -572,8 +572,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
@@ -6348,18 +6348,6 @@ packages:
   purls: []
   size: 3526350
   timestamp: 1769460339384
-- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
-  sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
-  md5: d0fc809fa4c4d85e959ce4ab6e1de800
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/toml?source=hash-mapping
-  size: 24017
-  timestamp: 1764486833072
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58
@@ -6372,6 +6360,17 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 21561
   timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
+  sha256: b35082091c8efd084e51bc3a4a2d3b07897eff232aaf58cbc0f959b6291a6a93
+  md5: 385dca77a8b0ec6fa9b92cb62d09b43b
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=hash-mapping
+  size: 39224
+  timestamp: 1768476626454
 - pypi: https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl
   name: tornado
   version: 6.5.5
@@ -6555,9 +6554,9 @@ packages:
 - pypi: ./
   name: versionable
   version: 0.1.1.dev1
-  sha256: 4288749d1a8d880153cc30ab89c9e653bec8c605346fb8961b638e3615d62807
+  sha256: 562a81e6986d6ecba95fd0bdd847855fd624abe468c2fb86afa15113c08cd63a
   requires_dist:
-  - toml>=0.10 ; extra == 'toml'
+  - tomlkit>=0.13 ; extra == 'toml'
   - pyyaml>=6.0 ; extra == 'yaml'
   - numpy>=1.26 ; extra == 'hdf5'
   - h5py>=3.10 ; extra == 'hdf5'
@@ -6565,7 +6564,7 @@ packages:
   - numpy>=1.26 ; extra == 'all'
   - h5py>=3.10 ; extra == 'all'
   - hdf5plugin>=4.0 ; extra == 'all'
-  - toml>=0.10 ; extra == 'all'
+  - tomlkit>=0.13 ; extra == 'all'
   - pyyaml>=6.0 ; extra == 'all'
   - sphinx>=7 ; extra == 'docs'
   - myst-parser>=2 ; extra == 'docs'

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,7 +28,7 @@ ci-all = { cmd = "pixi run -e default ci && pixi run -e minimal ci", description
 python = ">=3.12,<3.14"
 
 [feature.toml.dependencies]
-toml = ">=0.10"
+tomlkit = ">=0.13"
 
 [feature.yaml.dependencies]
 pyyaml = ">=6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-toml = ["toml>=0.10"]
+toml = ["tomlkit>=0.13"]
 yaml = ["pyyaml>=6.0"]
 hdf5 = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0"]
-all = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0", "toml>=0.10", "pyyaml>=6.0"]
+all = ["numpy>=1.26", "h5py>=3.10", "hdf5plugin>=4.0", "tomlkit>=0.13", "pyyaml>=6.0"]
 docs = ["sphinx>=7", "myst-parser>=2", "furo"]
 dev = [
     "pytest>=8.0",
@@ -83,7 +83,7 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 
 [[tool.mypy.overrides]]
-module = ["numpy.*", "h5py.*", "hdf5plugin.*", "toml.*", "yaml.*"]
+module = ["numpy.*", "h5py.*", "hdf5plugin.*", "tomlkit.*", "yaml.*"]
 ignore_missing_imports = true
 
 

--- a/src/versionable/_backend.py
+++ b/src/versionable/_backend.py
@@ -69,7 +69,7 @@ def getBackend(path: Path | str, explicit: type[Backend] | None = None) -> Backe
     if ext not in _BACKEND_REGISTRY:
         hint = ""
         if ext == ".toml":
-            hint = " Install toml: `pip install toml`"
+            hint = " Install tomlkit: `pip install tomlkit`"
         elif ext in (".yaml", ".yml"):
             hint = " Install pyyaml: `pip install pyyaml`"
         elif ext in (".h5", ".hdf5"):

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -7,11 +7,11 @@ Nested Versionable objects use native TOML table syntax, with each
 nested object's metadata under its own ``[<field>.__versionable__]``
 sub-table::
 
+    name = "myapp"
+
     [__versionable__]
     object = "Config"
     version = 1
-
-    name = "myapp"
 
     [point]
     x = 1.0

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -33,15 +33,15 @@ TOML limitations compared to JSON:
 
 from __future__ import annotations
 
-import io
 import json
 from pathlib import Path
 from typing import Any, ClassVar
 
 try:
-    import toml
+    import tomlkit
+    from tomlkit.exceptions import TOMLKitError
 except ImportError as e:
-    raise ImportError("TOML backend requires toml — install it with: `pip install toml`") from e
+    raise ImportError("TOML backend requires tomlkit — install it with: `pip install tomlkit`") from e
 
 from versionable._backend import Backend, registerBackend
 from versionable._base import _resolveFields
@@ -90,7 +90,7 @@ class TomlBackend(Backend):
             data[key] = _toTomlSafe(value)
 
         try:
-            content = toml.dumps(data)
+            content = tomlkit.dumps(data)
             if commentDefaults:
                 content = _commentDefaultLines(content, fields, meta["name"])
             path.write_text(content, encoding="utf-8")
@@ -100,8 +100,8 @@ class TomlBackend(Backend):
     def load(self, path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
         try:
             text = path.read_text(encoding="utf-8")
-            data = toml.loads(text)
-        except (OSError, toml.TomlDecodeError) as e:
+            data: dict[str, Any] = tomlkit.parse(text).unwrap()
+        except (OSError, TOMLKitError) as e:
             raise BackendError(f"Failed to read TOML from {path}: {e}") from e
 
         if not isinstance(data, dict):
@@ -219,9 +219,7 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
             if val is not None:
                 defaultSerialized[name] = _toTomlSafe(val)
 
-    buf = io.StringIO()
-    toml.dump(defaultSerialized, buf)
-    defaultLineSet = set(buf.getvalue().splitlines())
+    defaultLineSet = set(tomlkit.dumps(defaultSerialized).splitlines())
 
     # Walk input lines
     lines = content.splitlines(keepends=True)

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -44,7 +44,7 @@ except ImportError as e:
     raise ImportError("TOML backend requires tomlkit — install it with: `pip install tomlkit`") from e
 
 from versionable._backend import Backend, registerBackend
-from versionable._base import _resolveFields
+from versionable._base import Versionable, _resolveFields
 from versionable._types import serialize
 from versionable.errors import BackendError
 
@@ -90,9 +90,7 @@ class TomlBackend(Backend):
             data[key] = _toTomlSafe(value)
 
         try:
-            content = tomlkit.dumps(data)
-            if commentDefaults:
-                content = _commentDefaultLines(content, fields, meta["name"])
+            content = _emitWithCommentedDefaults(data, cls) if commentDefaults else tomlkit.dumps(data)
             path.write_text(content, encoding="utf-8")
         except (OSError, TypeError) as e:
             raise BackendError(f"Failed to write TOML to {path}: {e}") from e
@@ -175,37 +173,59 @@ def _fromTomlSafe(value: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) -> str:
-    """Comment out TOML value lines that match the class defaults.
+def _emitWithCommentedDefaults(data: dict[str, Any], cls: type) -> str:
+    """Build TOML output where fields at their default value appear as comment lines.
 
-    Section headers and ``__versionable__`` blocks are never commented — only
-    individual field value lines.  This ensures nested Versionable
-    sections remain structurally intact so users can uncomment just
-    the fields they need.
+    Walks `data` in parallel with the dataclass's defaults. For each scalar/list field
+    whose serialized value matches the default, emit a ``# key = value`` comment instead
+    of a key-value pair. Section headers and ``__versionable__`` envelope tables are
+    never commented. Nested Versionable tables recurse with their own defaults.
     """
+    doc = tomlkit.document()
+    _addContainerWithDefaults(doc, data, cls)
+    return tomlkit.dumps(doc)
+
+
+def _addContainerWithDefaults(
+    container: Any,  # tomlkit.TOMLDocument | tomlkit.items.Table
+    data: dict[str, Any],
+    cls: type | None,
+) -> None:
+    """Populate `container` with `data`; commented defaults driven by `cls`."""
+    defaults = _classDefaultsToml(cls) if cls is not None else {}
+    fieldTypes = _resolveFields(cls) if cls is not None else {}
+
+    for key, value in data.items():
+        if key == "__versionable__":
+            sub = tomlkit.table()
+            for metaKey, metaVal in value.items():
+                sub[metaKey] = metaVal
+            container[key] = sub
+            continue
+
+        if isinstance(value, dict):
+            sub = tomlkit.table()
+            nestedCls = _findVersionableType(fieldTypes.get(key))
+            _addContainerWithDefaults(sub, value, nestedCls)
+            container[key] = sub
+            continue
+
+        if key in defaults and value == defaults[key]:
+            scratch = tomlkit.document()
+            scratch[key] = value
+            line = tomlkit.dumps(scratch).rstrip("\n")
+            container.add(tomlkit.comment(line))
+        else:
+            container[key] = value
+
+
+def _classDefaultsToml(cls: type) -> dict[str, Any]:
+    """Compute serialized + TOML-safe defaults for each field of `cls`."""
     import dataclasses
 
-    from versionable._base import Versionable, _resolveFields, metadata, registeredClasses
-    from versionable._types import serialize
-
-    # Find the class — check registry first, then scan subclasses
-    cls: type | None = registeredClasses().get(objectName)
-    if cls is None:
-        for sub in Versionable.__subclasses__():
-            try:
-                if metadata(sub).name == objectName:
-                    cls = sub
-                    break
-            except Exception:
-                continue
-    if cls is None:
-        return content
-
-    # Build a set of TOML lines that represent the default values (per-field,
-    # to handle classes with required fields that can't be default-constructed).
     dcFields = {f.name: f for f in dataclasses.fields(cls)}
     resolvedFields = _resolveFields(cls)
-    defaultSerialized: dict[str, object] = {}
+    out: dict[str, Any] = {}
     for name, tp in resolvedFields.items():
         dcField = dcFields.get(name)
         if dcField is None:
@@ -213,45 +233,23 @@ def _commentDefaultLines(content: str, fields: dict[str, Any], objectName: str) 
         if dcField.default is not dataclasses.MISSING:
             val = serialize(dcField.default, tp)
             if val is not None:
-                defaultSerialized[name] = _toTomlSafe(val)
+                out[name] = _toTomlSafe(val)
         elif dcField.default_factory is not dataclasses.MISSING:
             val = serialize(dcField.default_factory(), tp)
             if val is not None:
-                defaultSerialized[name] = _toTomlSafe(val)
+                out[name] = _toTomlSafe(val)
+    return out
 
-    defaultLineSet = set(tomlkit.dumps(defaultSerialized).splitlines())
 
-    # Walk input lines
-    lines = content.splitlines(keepends=True)
-    result: list[str] = []
-    inMetaSection = False
+def _findVersionableType(fieldType: Any) -> type | None:
+    """If `fieldType` is a Versionable subclass, return it; else None.
 
-    for line in lines:
-        stripped = line.rstrip("\n")
-
-        # Section header — always keep uncommented
-        if stripped.startswith("["):
-            inMetaSection = "__versionable__" in stripped
-            result.append(line)
-            continue
-
-        # Blank / comment line — pass through
-        if not stripped or stripped.startswith("#"):
-            result.append(line)
-            continue
-
-        # __versionable__ section — always keep uncommented
-        if inMetaSection:
-            result.append(line)
-            continue
-
-        # Value line — check against defaults
-        if stripped in defaultLineSet:
-            result.append("# " + line)
-        else:
-            result.append(line)
-
-    return "".join(result)
+    Parameterized types like ``list[Inner]`` are not unwrapped — commentDefaults
+    does not recurse into list elements (matches existing behavior).
+    """
+    if isinstance(fieldType, type) and issubclass(fieldType, Versionable):
+        return fieldType
+    return None
 
 
 # Register for .toml extension

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -191,25 +191,19 @@ def _addContainerWithDefaults(
     data: dict[str, Any],
     cls: type | None,
 ) -> None:
-    """Populate `container` with `data`; commented defaults driven by `cls`."""
+    """Populate `container` with `data`; commented defaults driven by `cls`.
+
+    Emits in three passes to satisfy the TOML structural rule that scalars
+    must precede any `[table]` header at a given level — without this, an
+    uncommented default would land inside the wrong table.
+    """
     defaults = _classDefaultsToml(cls) if cls is not None else {}
     fieldTypes = _resolveFields(cls) if cls is not None else {}
 
+    # Pass 1: scalar / list fields (with comment-out for at-default values)
     for key, value in data.items():
-        if key == "__versionable__":
-            sub = tomlkit.table()
-            for metaKey, metaVal in value.items():
-                sub[metaKey] = metaVal
-            container[key] = sub
+        if key == "__versionable__" or isinstance(value, dict):
             continue
-
-        if isinstance(value, dict):
-            sub = tomlkit.table()
-            nestedCls = _findVersionableType(fieldTypes.get(key))
-            _addContainerWithDefaults(sub, value, nestedCls)
-            container[key] = sub
-            continue
-
         if key in defaults and value == defaults[key]:
             scratch = tomlkit.document()
             scratch[key] = value
@@ -217,6 +211,23 @@ def _addContainerWithDefaults(
             container.add(tomlkit.comment(line))
         else:
             container[key] = value
+
+    # Pass 2: __versionable__ envelope (always uncommented)
+    envelope = data.get("__versionable__")
+    if isinstance(envelope, dict):
+        sub = tomlkit.table()
+        for metaKey, metaVal in envelope.items():
+            sub[metaKey] = metaVal
+        container["__versionable__"] = sub
+
+    # Pass 3: nested Versionable / table fields (recurse)
+    for key, value in data.items():
+        if key == "__versionable__" or not isinstance(value, dict):
+            continue
+        sub = tomlkit.table()
+        nestedCls = _findVersionableType(fieldTypes.get(key))
+        _addContainerWithDefaults(sub, value, nestedCls)
+        container[key] = sub
 
 
 def _classDefaultsToml(cls: type) -> dict[str, Any]:

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -92,7 +92,7 @@ class TomlBackend(Backend):
         try:
             content = _emitWithCommentedDefaults(data, cls) if commentDefaults else tomlkit.dumps(data)
             path.write_text(content, encoding="utf-8")
-        except (OSError, TypeError) as e:
+        except (OSError, TypeError, TOMLKitError) as e:
             raise BackendError(f"Failed to write TOML to {path}: {e}") from e
 
     def load(self, path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -209,8 +209,10 @@ def _addContainerWithDefaults(
         if key in defaults and value == defaults[key]:
             scratch = tomlkit.document()
             scratch[key] = value
-            line = tomlkit.dumps(scratch).rstrip("\n")
-            container.add(tomlkit.comment(line))
+            # Multi-line defaults (e.g. list of nested tables) need every
+            # output line commented — tomlkit.comment wraps a single line.
+            for line in tomlkit.dumps(scratch).rstrip("\n").split("\n"):
+                container.add(tomlkit.comment(line))
         else:
             container[key] = value
 

--- a/src/versionable/_toml_backend.py
+++ b/src/versionable/_toml_backend.py
@@ -183,7 +183,9 @@ def _emitWithCommentedDefaults(data: dict[str, Any], cls: type) -> str:
     """
     doc = tomlkit.document()
     _addContainerWithDefaults(doc, data, cls)
-    return tomlkit.dumps(doc)
+    # str() coerces the return type for the minimal env's mypy run, where
+    # tomlkit isn't installed and dumps() resolves to Any.
+    return str(tomlkit.dumps(doc))
 
 
 def _addContainerWithDefaults(

--- a/tests/test_cross_backend_roundtrip.py
+++ b/tests/test_cross_backend_roundtrip.py
@@ -114,7 +114,7 @@ class _EmptyCollections(Versionable, version=1, hash="6c8e40", register=False):
 _DICT_BACKENDS: list[str] = [".json"]
 
 try:
-    import toml as _toml  # noqa: F401
+    import tomlkit as _tomlkit  # noqa: F401
 
     _DICT_BACKENDS.append(".toml")
 except ImportError:

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -26,7 +26,7 @@ from versionable import CircularReferenceError, Versionable
 _DICT_BACKENDS: list[str] = [".json"]
 
 try:
-    import toml as _toml  # noqa: F401
+    import tomlkit as _tomlkit  # noqa: F401
 
     _DICT_BACKENDS.append(".toml")
 except ImportError:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -20,7 +20,7 @@ from versionable.errors import MigrationError, UpgradeRequiredError
 
 def _hasToml() -> bool:
     try:
-        import toml  # noqa: F401
+        import tomlkit  # noqa: F401
 
         return True
     except ImportError:

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -7,7 +7,7 @@ import pytest
 
 pytest.importorskip("tomlkit")
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 try:
@@ -37,6 +37,24 @@ if _HAS_NUMPY:
 
         label: str
         data: npt.NDArray[np.float64]
+
+
+# Module-level helpers for nested commentDefaults tests.  Defining these
+# at module scope (not inside a test method) lets `typing.get_type_hints`
+# resolve the forward reference under `from __future__ import annotations`,
+# so the nested class is recognized and its default-fields get commented.
+# Hashes are pinned literals per project convention; if you change a field
+# type below, expect a HashMismatchError telling you the new hash.
+@dataclass
+class _NestedHost(Versionable, version=1, hash="1c4d34", register=False):
+    host: str = "localhost"
+    port: int = 5432
+
+
+@dataclass
+class _NestedRoot(Versionable, version=1, hash="f4760d", register=False):
+    label: str
+    db: _NestedHost = field(default_factory=_NestedHost)
 
 
 class TestTomlMetadata:
@@ -153,6 +171,39 @@ class TestTomlCommentDefaults:
         # Commented defaults are not present as keys
         assert "debug" not in parsed
         assert "retries" not in parsed
+
+    def test_uncommentingDefaultRoundTrips(self, tmp_path: Path) -> None:
+        """A user uncommenting a default line must produce a valid override at the right path."""
+        obj = SimpleConfig(name="test")
+        p = tmp_path / "out.toml"
+        versionable.save(obj, p, commentDefaults=True)
+
+        # Simulate a user uncommenting "# debug = false" and changing the value
+        text = p.read_text()
+        assert "# debug = false" in text  # baseline
+        modified = text.replace("# debug = false", "debug = true")
+        p.write_text(modified)
+
+        loaded = versionable.load(SimpleConfig, p)
+        assert loaded.debug is True, (
+            f"uncommented `debug = true` did not override default; file content was:\n{p.read_text()}"
+        )
+
+    def test_uncommentingNestedDefaultRoundTrips(self, tmp_path: Path) -> None:
+        """Same as above but for a field inside a nested Versionable."""
+        obj = _NestedRoot(label="x")
+        p = tmp_path / "out.toml"
+        versionable.save(obj, p, commentDefaults=True)
+
+        text = p.read_text()
+        assert "# host = " in text
+        modified = text.replace('# host = "localhost"', 'host = "elsewhere"')
+        p.write_text(modified)
+
+        loaded = versionable.load(_NestedRoot, p)
+        assert loaded.db.host == "elsewhere", (
+            f"uncommented nested host did not override default; file content was:\n{p.read_text()}"
+        )
 
 
 class TestTomlLiteral:

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("toml")
+pytest.importorskip("tomlkit")
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,26 +41,26 @@ if _HAS_NUMPY:
 
 class TestTomlMetadata:
     def test_metaTableInFile(self, tmp_path: Path) -> None:
-        import toml
+        import tomlkit
 
         obj = SimpleConfig(name="test")
         p = tmp_path / "out.toml"
         versionable.save(obj, p)
 
-        data = toml.loads(p.read_text())
+        data = tomlkit.parse(p.read_text()).unwrap()
         assert "__versionable__" in data
         assert data["__versionable__"]["object"] == "SimpleConfig"
         assert data["__versionable__"]["version"] == 1
 
     def test_nestedUsesNativeTable(self, tmp_path: Path) -> None:
         """Nested Versionable should use TOML table syntax, not JSON wrapper."""
-        import toml
+        import tomlkit
 
         obj = WithNested(name="origin", point=Inner(x=1.0, y=2.0))
         p = tmp_path / "out.toml"
         versionable.save(obj, p)
 
-        data = toml.loads(p.read_text())
+        data = tomlkit.parse(p.read_text()).unwrap()
         # point should be a native TOML table, not a __ver_json__ wrapper
         assert isinstance(data["point"], dict)
         assert "__ver_json__" not in data["point"]
@@ -148,11 +148,11 @@ class TestTomlLiteral:
         assert loaded.mode == "slow"
 
     def test_invalidLiteralRaises(self, tmp_path: Path) -> None:
-        import toml
+        import tomlkit
 
         p = tmp_path / "out.toml"
         p.write_text(
-            toml.dumps(
+            tomlkit.dumps(
                 {
                     "__versionable__": {"object": "WithLiteral", "version": 1, "hash": ""},
                     "name": "test",

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -59,6 +59,17 @@ class _NestedRoot(Versionable, version=1, hash="f4760d", register=False):
     db: _NestedHost = field(default_factory=_NestedHost)
 
 
+@dataclass
+class _ListItem(Versionable, version=1, hash="bc0926", register=False):
+    a: int = 1
+
+
+@dataclass
+class _ListRoot(Versionable, version=1, hash="cd806f", register=False):
+    label: str
+    items: list[_ListItem] = field(default_factory=lambda: [_ListItem()])
+
+
 class TestTomlMetadata:
     def test_metaTableInFile(self, tmp_path: Path) -> None:
         obj = SimpleConfig(name="test")
@@ -200,6 +211,25 @@ class TestTomlCommentDefaults:
         assert loaded.db.host == "elsewhere", (
             f"uncommented nested host did not override default; file content was:\n{p.read_text()}"
         )
+
+    def test_listOfVersionablesDefaultIsFullyCommented(self, tmp_path: Path) -> None:
+        """A list-of-Versionables default serializes to multi-line TOML; every line must be commented."""
+        obj = _ListRoot(label="x")  # `items` left at default
+        p = tmp_path / "out.toml"
+        versionable.save(obj, p, commentDefaults=True)
+
+        text = p.read_text()
+        # Every emitted line for the `items` array-of-tables must be commented.
+        # If only the first line was commented, an uncommented `a = 1` (etc.) would land
+        # as an active key in some other table.
+        assert "# [[items]]" in text
+        # No bare `[[items]]` or sub-table header at line start (would mean uncommented).
+        for line in text.splitlines():
+            assert not line.startswith("[[items]]"), f"uncommented line: {line!r}"
+            assert not line.startswith("[items."), f"uncommented line: {line!r}"
+        # Re-parse: the commented `items` should not exist as a key.
+        parsed = tomlkit.parse(text).unwrap()
+        assert "items" not in parsed
 
 
 class TestTomlLiteral:

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     _HAS_NUMPY = False
 
+import tomlkit  # must follow pytest.importorskip above
+
 import versionable
 from versionable._base import Versionable
 from versionable.errors import BackendError, ConverterError
@@ -59,8 +61,6 @@ class _NestedRoot(Versionable, version=1, hash="f4760d", register=False):
 
 class TestTomlMetadata:
     def test_metaTableInFile(self, tmp_path: Path) -> None:
-        import tomlkit
-
         obj = SimpleConfig(name="test")
         p = tmp_path / "out.toml"
         versionable.save(obj, p)
@@ -72,8 +72,6 @@ class TestTomlMetadata:
 
     def test_nestedUsesNativeTable(self, tmp_path: Path) -> None:
         """Nested Versionable should use TOML table syntax, not JSON wrapper."""
-        import tomlkit
-
         obj = WithNested(name="origin", point=Inner(x=1.0, y=2.0))
         p = tmp_path / "out.toml"
         versionable.save(obj, p)
@@ -158,8 +156,6 @@ class TestTomlCommentDefaults:
 
     def test_commentDefaultsEmitsValidToml(self, tmp_path: Path) -> None:
         """commentDefaults output is parseable as valid TOML and round-trips."""
-        import tomlkit
-
         obj = SimpleConfig(name="test")
         p = tmp_path / "out.toml"
         versionable.save(obj, p, commentDefaults=True)
@@ -215,8 +211,6 @@ class TestTomlLiteral:
         assert loaded.mode == "slow"
 
     def test_invalidLiteralRaises(self, tmp_path: Path) -> None:
-        import tomlkit
-
         p = tmp_path / "out.toml"
         p.write_text(
             tomlkit.dumps(
@@ -323,7 +317,5 @@ class TestTomlBackCompat:
 
 def test_dependencyImport() -> None:
     """tomlkit imports cleanly — guardrail against accidental dep removal."""
-    import tomlkit
-
     assert hasattr(tomlkit, "parse")
     assert hasattr(tomlkit, "dumps")

--- a/tests/test_toml_backend.py
+++ b/tests/test_toml_backend.py
@@ -138,6 +138,22 @@ class TestTomlCommentDefaults:
         assert 'object = "Inner"' in text
         assert "# object" not in text
 
+    def test_commentDefaultsEmitsValidToml(self, tmp_path: Path) -> None:
+        """commentDefaults output is parseable as valid TOML and round-trips."""
+        import tomlkit
+
+        obj = SimpleConfig(name="test")
+        p = tmp_path / "out.toml"
+        versionable.save(obj, p, commentDefaults=True)
+
+        # Parsing should not raise — the file with commented defaults is valid TOML
+        parsed = tomlkit.parse(p.read_text()).unwrap()
+        assert parsed["__versionable__"]["object"] == "SimpleConfig"
+        assert parsed["name"] == "test"
+        # Commented defaults are not present as keys
+        assert "debug" not in parsed
+        assert "retries" not in parsed
+
 
 class TestTomlLiteral:
     def test_literalRoundTrip(self, tmp_path: Path) -> None:
@@ -252,3 +268,11 @@ class TestTomlBackCompat:
         loaded = versionable.load(_TomlArrLegacy, p)
         assert loaded.label == "legacy-array"
         np.testing.assert_array_equal(loaded.data, np.array([7.0, 8.0, 9.0]))
+
+
+def test_dependencyImport() -> None:
+    """tomlkit imports cleanly — guardrail against accidental dep removal."""
+    import tomlkit
+
+    assert hasattr(tomlkit, "parse")
+    assert hasattr(tomlkit, "dumps")


### PR DESCRIPTION
**Description:** Replace the unmaintained `toml` package (last release Nov 2020) with
[`tomlkit`](https://github.com/python-poetry/tomlkit) in the TOML backend, and rebuild the
`commentDefaults=True` code path on top of tomlkit's structural document API.

Closes #27.

**Changes:**

- Swap `toml` for `tomlkit` in `pixi.toml`, `pyproject.toml`, `pixi.lock`, and the `[tool.mypy]`
  module override; update `pip install` hints in `README.md`, `docs/AGENT.md`, and the runtime
  install-hint string in `_backend.py`.
- Rewrite `_toml_backend.py` to call `tomlkit.parse(text).unwrap()` on read and `tomlkit.dumps(data)`
  on write; catch `tomlkit.exceptions.TOMLKitError` instead of `toml.TomlDecodeError`.
- Replace the line-walking `_commentDefaultLines` with `_emitWithCommentedDefaults`, which builds
  a `tomlkit.document()` and emits at-default fields as `tomlkit.comment(...)` lines, recursing
  into nested Versionable tables.
- Three-pass emission keeps root scalars (and nested-table scalars) before their `[__versionable__]`
  envelope, so a user uncommenting `# debug = false` correctly overrides the dataclass field instead
  of silently landing inside the meta table.
- Add `test_commentDefaultsEmitsValidToml`, `test_dependencyImport`, and two
  `test_uncommenting*RoundTrips` regression tests; update tests that imported `toml` directly.
- Refresh `examples/comment_defaults.py` expected-output block, the `commentDefaults` example in
  `docs/backends.md` (and add a note about the round-trip-comments limitation), and `CHANGELOG.md`.

**Tests performed:**

- `pixi run --environment default cleanup && pixi run --environment default pytest` — 453 tests pass.
- `examples/comment_defaults.py` runs and emits the documented output.
- Manual uncomment-and-reload check on a SimpleConfig and a nested Versionable.

**Out of scope (planned for a follow-up):**

- Round-trip preservation of user-added comments. Documented as a limitation in `docs/backends.md`
  and `CHANGELOG.md`.