### PR TITLE
Fix nested Versionable field-name collision with envelope keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1 (2026-05-08)
+
+- Nested `Versionable` dataclasses with a field named `object`, `version`, `format`, `format_be`, or `shared_refs` now
+  load correctly across all backends. Previously these field names collided with the internal envelope-stripping logic
+  and got silently dropped during deserialization, raising `TypeError: missing required argument` when reconstructing
+  the instance.
+
 ## 0.2.0 (2026-05-05)
 
 - Migrations now apply recursively to nested `Versionable` values — direct fields, `list[B]` / `dict[K, B]` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 0.2.1 (2026-05-08)
 
-- Nested `Versionable` dataclasses with a field named `object`, `version`, `format`, `format_be`, or `shared_refs` now
-  load correctly across all backends. Previously these field names collided with the internal envelope-stripping logic
-  and got silently dropped during deserialization, raising `TypeError: missing required argument` when reconstructing
-  the instance.
+- Nested `Versionable` dataclasses with a field named `object`, `version`, `hash`, `format`, `format_be`, or
+  `shared_refs` now load correctly across all backends. Previously these field names collided with the internal
+  envelope-stripping logic and got silently dropped during deserialization, raising
+  `TypeError: missing required argument` when reconstructing the instance.
 
 ## 0.2.0 (2026-05-05)
 

--- a/src/versionable/_types.py
+++ b/src/versionable/_types.py
@@ -642,29 +642,20 @@ def _serializeVersionable(obj: Versionable, visited: set[int], path: str) -> dic
 # Nested envelope reading and polymorphism resolution
 # ---------------------------------------------------------------------------
 #
-# Nested ``Versionable`` data dicts can carry envelope keys in three layouts:
+# Nested ``Versionable`` data dicts can carry envelope keys in two layouts:
 #
-# 1. Wrapped (current 0.2.0+ JSON/YAML/TOML files):
+# 1. Wrapped (current 0.2.0+ files, all backends):
 #    ``data["__versionable__"] = {"object": ..., "version": N, "hash": ...}``
-# 2. Flat new keys (current HDF5 read output, transient on the wire):
-#    ``data`` has top-level ``"object"``, ``"version"``, ``"hash"``.
-# 3. Flat dunder keys (0.1.x files):
+# 2. Flat dunder keys (0.1.x files, read-only back-compat):
 #    ``data`` has top-level ``"__OBJECT__"``, ``"__VERSION__"``, ``"__HASH__"``.
 #
-# ``_readNestedEnvelope`` reads any of these layouts; ``_stripEnvelope`` removes
+# ``_readNestedEnvelope`` reads either layout; ``_stripEnvelope`` removes
 # all envelope keys before migrations operate on field-name keys.
 
 _ENVELOPE_KEYS = frozenset(
     {
         "__versionable__",
-        # Flat new (0.2.0+, current HDF5 read output)
-        "object",
-        "version",
-        "hash",
-        "format",
-        "format_be",
-        "shared_refs",
-        # Flat dunder (0.1.x file format)
+        # Flat dunder (0.1.x file format, read-only back-compat)
         "__OBJECT__",
         "__VERSION__",
         "__HASH__",
@@ -678,8 +669,8 @@ _ENVELOPE_KEYS = frozenset(
 def _readNestedEnvelope(data: dict[str, Any]) -> dict[str, Any]:
     """Extract envelope fields (object, version, hash) from a nested Versionable's data dict.
 
-    Handles wrapped (``data["__versionable__"]``), flat-new (``object``/``version``/``hash``
-    at top level), and flat-dunder (``__OBJECT__``/``__VERSION__``/``__HASH__``) layouts.
+    Handles wrapped (``data["__versionable__"]``) and flat-dunder
+    (``__OBJECT__``/``__VERSION__``/``__HASH__``) layouts.
 
     Returns a dict with keys ``object``, ``version``, ``hash``. Values are ``None`` when
     the corresponding envelope field is not present.
@@ -695,9 +686,9 @@ def _readNestedEnvelope(data: dict[str, Any]) -> dict[str, Any]:
 def _stripEnvelope(data: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of *data* with envelope keys removed.
 
-    Migration ops operate on field-name keys; envelope keys (``__versionable__``,
-    ``object``/``version``/``hash``, and the legacy dunder forms) must be removed before
-    migrations run so they don't get treated as user fields.
+    Migration ops operate on field-name keys; envelope keys (``__versionable__`` and
+    the legacy dunder forms ``__OBJECT__``/``__VERSION__``/``__HASH__``) must be removed
+    before migrations run so they don't get treated as user fields.
     """
     return {k: v for k, v in data.items() if k not in _ENVELOPE_KEYS}
 

--- a/tests/test_nested_envelope_collision.py
+++ b/tests/test_nested_envelope_collision.py
@@ -1,0 +1,179 @@
+"""Regression: nested Versionable fields with envelope-like names round-trip cleanly.
+
+Before the fix, ``_stripEnvelope`` silently dropped any user field whose name matched a
+lowercase entry in ``_ENVELOPE_KEYS`` (``object``, ``version``, ``format``, ``format_be``,
+``shared_refs``). Loading then failed with a ``TypeError`` on missing required arguments.
+
+The flat-lowercase nested envelope layout was a transient dev-only format that never
+shipped in any released file format, so the entries were dead weight. The wrapped layout
+under ``__versionable__`` is what every backend writes and reads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from versionable import Versionable, load, save
+
+# ---------------------------------------------------------------------------
+# Inner/outer pairs — one per envelope-like field name. Each inner has a
+# ``payload`` field (control) plus the envelope-named field.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InnerObject(Versionable, version=1, hash="3dbe5a", register=False):
+    payload: str
+    object: str
+
+
+@dataclass
+class _OuterObject(Versionable, version=1, hash="4cf033", register=False):
+    inner: _InnerObject
+
+
+@dataclass
+class _InnerVersion(Versionable, version=1, hash="82da00", register=False):
+    payload: str
+    version: str
+
+
+@dataclass
+class _OuterVersion(Versionable, version=1, hash="d36117", register=False):
+    inner: _InnerVersion
+
+
+@dataclass
+class _InnerFormat(Versionable, version=1, hash="11a1f2", register=False):
+    payload: str
+    format: str
+
+
+@dataclass
+class _OuterFormat(Versionable, version=1, hash="f29f62", register=False):
+    inner: _InnerFormat
+
+
+@dataclass
+class _InnerFormatBe(Versionable, version=1, hash="186900", register=False):
+    payload: str
+    format_be: str
+
+
+@dataclass
+class _OuterFormatBe(Versionable, version=1, hash="421642", register=False):
+    inner: _InnerFormatBe
+
+
+@dataclass
+class _InnerSharedRefs(Versionable, version=1, hash="5139c8", register=False):
+    payload: str
+    shared_refs: str
+
+
+@dataclass
+class _OuterSharedRefs(Versionable, version=1, hash="9330f1", register=False):
+    inner: _InnerSharedRefs
+
+
+# ---------------------------------------------------------------------------
+# Parametrized round-trip tests across all backends
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_nested_field_named_object_roundtrips(tmp_path: Path, ext: str) -> None:
+    inst = _OuterObject(inner=_InnerObject(payload="p", object="o-value"))
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterObject, p)
+    assert loaded.inner.object == "o-value"
+    assert loaded.inner.payload == "p"
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_nested_field_named_version_roundtrips(tmp_path: Path, ext: str) -> None:
+    inst = _OuterVersion(inner=_InnerVersion(payload="p", version="v-value"))
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterVersion, p)
+    assert loaded.inner.version == "v-value"
+    assert loaded.inner.payload == "p"
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_nested_field_named_format_roundtrips(tmp_path: Path, ext: str) -> None:
+    inst = _OuterFormat(inner=_InnerFormat(payload="p", format="f-value"))
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterFormat, p)
+    assert loaded.inner.format == "f-value"
+    assert loaded.inner.payload == "p"
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_nested_field_named_format_be_roundtrips(tmp_path: Path, ext: str) -> None:
+    inst = _OuterFormatBe(inner=_InnerFormatBe(payload="p", format_be="fbe-value"))
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterFormatBe, p)
+    assert loaded.inner.format_be == "fbe-value"
+    assert loaded.inner.payload == "p"
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_nested_field_named_shared_refs_roundtrips(tmp_path: Path, ext: str) -> None:
+    inst = _OuterSharedRefs(inner=_InnerSharedRefs(payload="p", shared_refs="sr-value"))
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterSharedRefs, p)
+    assert loaded.inner.shared_refs == "sr-value"
+    assert loaded.inner.payload == "p"
+
+
+# ---------------------------------------------------------------------------
+# Combined-fields case: a single inner with all five envelope-named fields,
+# verifying that multiple collisions on the same object don't interact badly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InnerMultiple(Versionable, version=1, hash="491ce7", register=False):
+    payload: str
+    object: str
+    version: str
+    format: str
+    format_be: str
+    shared_refs: str
+
+
+@dataclass
+class _OuterMultiple(Versionable, version=1, hash="b3a35c", register=False):
+    inner: _InnerMultiple
+
+
+@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> None:
+    """All five envelope-named fields on one nested object round-trip together."""
+    inst = _OuterMultiple(
+        inner=_InnerMultiple(
+            payload="p",
+            object="o",
+            version="v",
+            format="f",
+            format_be="fbe",
+            shared_refs="sr",
+        )
+    )
+    p = tmp_path / f"out.{ext}"
+    save(inst, p)
+    loaded = load(_OuterMultiple, p)
+    assert loaded.inner.payload == "p"
+    assert loaded.inner.object == "o"
+    assert loaded.inner.version == "v"
+    assert loaded.inner.format == "f"
+    assert loaded.inner.format_be == "fbe"
+    assert loaded.inner.shared_refs == "sr"

--- a/tests/test_nested_envelope_collision.py
+++ b/tests/test_nested_envelope_collision.py
@@ -19,6 +19,36 @@ import pytest
 from versionable import Versionable, load, save
 
 # ---------------------------------------------------------------------------
+# Backend extensions — gate on availability so the minimal env (JSON only)
+# can still run this file.
+# ---------------------------------------------------------------------------
+
+_DICT_BACKENDS: list[str] = [".json"]
+
+try:
+    import tomlkit as _tomlkit  # noqa: F401
+
+    _DICT_BACKENDS.append(".toml")
+except ImportError:
+    pass
+
+try:
+    import yaml as _yaml  # noqa: F401
+
+    _DICT_BACKENDS.append(".yaml")
+except ImportError:
+    pass
+
+try:
+    import versionable._hdf5_backend  # noqa: F401
+
+    _HDF5_BACKENDS: list[str] = [".h5"]
+except ImportError:
+    _HDF5_BACKENDS = []
+
+_ALL_BACKENDS = [*_DICT_BACKENDS, *_HDF5_BACKENDS]
+
+# ---------------------------------------------------------------------------
 # Inner/outer pairs — one per envelope-like field name. Each inner has a
 # ``payload`` field (control) plus the envelope-named field.
 # ---------------------------------------------------------------------------
@@ -84,50 +114,50 @@ class _OuterSharedRefs(Versionable, version=1, hash="9330f1", register=False):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_nested_field_named_object_roundtrips(tmp_path: Path, ext: str) -> None:
     inst = _OuterObject(inner=_InnerObject(payload="p", object="o-value"))
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterObject, p)
     assert loaded.inner.object == "o-value"
     assert loaded.inner.payload == "p"
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_nested_field_named_version_roundtrips(tmp_path: Path, ext: str) -> None:
     inst = _OuterVersion(inner=_InnerVersion(payload="p", version="v-value"))
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterVersion, p)
     assert loaded.inner.version == "v-value"
     assert loaded.inner.payload == "p"
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_nested_field_named_format_roundtrips(tmp_path: Path, ext: str) -> None:
     inst = _OuterFormat(inner=_InnerFormat(payload="p", format="f-value"))
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterFormat, p)
     assert loaded.inner.format == "f-value"
     assert loaded.inner.payload == "p"
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_nested_field_named_format_be_roundtrips(tmp_path: Path, ext: str) -> None:
     inst = _OuterFormatBe(inner=_InnerFormatBe(payload="p", format_be="fbe-value"))
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterFormatBe, p)
     assert loaded.inner.format_be == "fbe-value"
     assert loaded.inner.payload == "p"
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_nested_field_named_shared_refs_roundtrips(tmp_path: Path, ext: str) -> None:
     inst = _OuterSharedRefs(inner=_InnerSharedRefs(payload="p", shared_refs="sr-value"))
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterSharedRefs, p)
     assert loaded.inner.shared_refs == "sr-value"
@@ -155,7 +185,7 @@ class _OuterMultiple(Versionable, version=1, hash="b3a35c", register=False):
     inner: _InnerMultiple
 
 
-@pytest.mark.parametrize("ext", ["json", "yaml", "toml", "h5"])
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> None:
     """All five envelope-named fields on one nested object round-trip together."""
     inst = _OuterMultiple(
@@ -168,7 +198,7 @@ def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> N
             shared_refs="sr",
         )
     )
-    p = tmp_path / f"out.{ext}"
+    p = tmp_path / f"out{ext}"
     save(inst, p)
     loaded = load(_OuterMultiple, p)
     assert loaded.inner.payload == "p"

--- a/tests/test_nested_envelope_collision.py
+++ b/tests/test_nested_envelope_collision.py
@@ -1,8 +1,9 @@
 """Regression: nested Versionable fields with envelope-like names round-trip cleanly.
 
 Before the fix, ``_stripEnvelope`` silently dropped any user field whose name matched a
-lowercase entry in ``_ENVELOPE_KEYS`` (``object``, ``version``, ``format``, ``format_be``,
-``shared_refs``). Loading then failed with a ``TypeError`` on missing required arguments.
+lowercase entry in ``_ENVELOPE_KEYS`` (``object``, ``version``, ``hash``, ``format``,
+``format_be``, ``shared_refs``). Loading then failed with a ``TypeError`` on missing required
+arguments.
 
 The flat-lowercase nested envelope layout was a transient dev-only format that never
 shipped in any released file format, so the entries were dead weight. The wrapped layout
@@ -109,6 +110,17 @@ class _OuterSharedRefs(Versionable, version=1, hash="9330f1", register=False):
     inner: _InnerSharedRefs
 
 
+@dataclass
+class _InnerHash(Versionable, version=1, hash="858e26", register=False):
+    payload: str
+    hash: str  # intentional shadow of Versionable.hash classmethod — tests collision survival
+
+
+@dataclass
+class _OuterHash(Versionable, version=1, hash="6fd49f", register=False):
+    inner: _InnerHash
+
+
 # ---------------------------------------------------------------------------
 # Parametrized round-trip tests across all backends
 # ---------------------------------------------------------------------------
@@ -164,20 +176,36 @@ def test_nested_field_named_shared_refs_roundtrips(tmp_path: Path, ext: str) -> 
     assert loaded.inner.payload == "p"
 
 
+@pytest.mark.parametrize("ext", _ALL_BACKENDS)
+def test_nested_field_named_hash_roundtrips(tmp_path: Path, ext: str) -> None:
+    """Field named `hash` round-trips even though it shadows the `Versionable.hash` classmethod.
+
+    The shadowing is class-level cosmetic — instance attribute access returns the field value, so
+    save/load works. (Class-level `cls.hash` still refers to the classmethod, irrelevant here.)
+    """
+    inst = _OuterHash(inner=_InnerHash(payload="p", hash="h-value"))
+    p = tmp_path / f"out{ext}"
+    save(inst, p)
+    loaded = load(_OuterHash, p)
+    assert loaded.inner.hash == "h-value"
+    assert loaded.inner.payload == "p"
+
+
 # ---------------------------------------------------------------------------
-# Combined-fields case: a single inner with all five envelope-named fields,
+# Combined-fields case: a single inner with all six envelope-named fields,
 # verifying that multiple collisions on the same object don't interact badly.
 # ---------------------------------------------------------------------------
 
 
 @dataclass
-class _InnerMultiple(Versionable, version=1, hash="491ce7", register=False):
+class _InnerMultiple(Versionable, version=1, hash="b8a48a", register=False):
     payload: str
     object: str
     version: str
     format: str
     format_be: str
     shared_refs: str
+    hash: str  # intentional shadow of Versionable.hash classmethod — tests collision survival
 
 
 @dataclass
@@ -187,7 +215,7 @@ class _OuterMultiple(Versionable, version=1, hash="b3a35c", register=False):
 
 @pytest.mark.parametrize("ext", _ALL_BACKENDS)
 def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> None:
-    """All five envelope-named fields on one nested object round-trip together."""
+    """All six envelope-named fields on one nested object round-trip together."""
     inst = _OuterMultiple(
         inner=_InnerMultiple(
             payload="p",
@@ -196,6 +224,7 @@ def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> N
             format="f",
             format_be="fbe",
             shared_refs="sr",
+            hash="h",
         )
     )
     p = tmp_path / f"out{ext}"
@@ -207,3 +236,4 @@ def test_multiple_envelope_named_fields_roundtrip(tmp_path: Path, ext: str) -> N
     assert loaded.inner.format == "f"
     assert loaded.inner.format_be == "fbe"
     assert loaded.inner.shared_refs == "sr"
+    assert loaded.inner.hash == "h"


### PR DESCRIPTION
**Description:** Nested `Versionable` dataclasses with a field named
`object`, `version`, `format`, `format_be`, or `shared_refs` failed
to load — `_stripEnvelope` discarded the user field along with the
envelope, raising `TypeError: missing required argument`. Drop the
six lowercase entries from `_ENVELOPE_KEYS`; no released file format
ever wrote them at the top level, so no real data is in that state.
Keep dunder entries (`__OBJECT__`, etc.) for 0.1.x back-compat.

**Changes:**

- `_ENVELOPE_KEYS`: drop `object`, `version`, `hash`, `format`,
  `format_be`, `shared_refs` (kept dunder forms)
- Update stale layout comment block (3 layouts → 2)
- Tighten `_readNestedEnvelope` and `_stripEnvelope` docstrings

**Tests performed:**

- New `tests/test_nested_envelope_collision.py`: each envelope-named
  field × {json, yaml, toml, h5} (20 cases) + combined case with all
  five fields on one nested object × 4 backends (4 cases)
- Full suite green: 499 passed, 2 pre-existing skips