### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -6553,8 +6553,8 @@ packages:
   timestamp: 1767320173250
 - pypi: ./
   name: versionable
-  version: 0.2.1.dev0
-  sha256: 22cdcff4358026b624f0788bfb14f9dd0a622acbf1b0010af058ee7d0acdb225
+  version: 0.2.1
+  sha256: bdc1d414795a47a7f6e8c6f8afc542c4115c568b3aec892b6fd390744b7b9803
   requires_dist:
   - tomlkit>=0.13 ; extra == 'toml'
   - pyyaml>=6.0 ; extra == 'yaml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "versionable"
-version = "0.2.1.dev0"
+version = "0.2.1"
 description = "Versioned persistence for Python dataclasses with hash validation, declarative migrations, and pluggable backends"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
**Description:** Cuts the 0.2.1 release. Single bug fix this cycle: nested `Versionable` field-name collision with envelope keys (PR #33).

**Changes:**

- `pyproject.toml`: 0.2.1.dev0 → 0.2.1
- `pixi.lock`: regenerated

**Tests performed:**

- `pixi run ci-all` (full CI in default + minimal envs): green

After merge, tag `v0.2.1` on main and create the GitHub Release.